### PR TITLE
BCEL-262: InvokeInstruction.getClassName(ConstantPoolGen)

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -107,6 +107,8 @@ Source compatible - Yes, sort of;
 For full information about API changes please see the extended Clirr report:
 
     http://commons.apache.org/bcel/clirr-report.html">
+      <action issue="BCEL-262" type="update" dev="britter" due-to="Mark Roberts">InvokeInstruction.getClassName(ConstantPoolGen) 
+                                          should throw an exception when it detects an array.</action>
       <action issue="BCEL-237" type="fix" dev="sebb">non-empty final arrays should be private as they are mutable.</action>
       <action issue="BCEL-230" type="update" dev="britter">Document the Java platform requirement clearly and early.</action>
       <action issue="BCEL-243" type="fix">Type.getType() needs to understand TypeVariableSignature(s).</action>

--- a/src/main/java/org/apache/bcel/generic/InvokeInstruction.java
+++ b/src/main/java/org/apache/bcel/generic/InvokeInstruction.java
@@ -21,6 +21,7 @@ import java.util.StringTokenizer;
 
 import org.apache.bcel.Const;
 import org.apache.bcel.classfile.Constant;
+import org.apache.bcel.classfile.ConstantCP;
 import org.apache.bcel.classfile.ConstantPool;
 
 /**
@@ -90,6 +91,24 @@ public abstract class InvokeInstruction extends FieldOrMethod implements Excepti
         return Type.getReturnTypeSize(signature);
     }
 
+    /**
+     * This overrides the deprecated version as we know here that the referenced class
+     * cannot be an array unless something has gone badly wrong.
+     * may legally be an array.
+     * *
+     * @return name of the referenced class/interface
+     * @throws IllegalArgumentException if the referenced class is an array (this should not happen)
+     */ 
+    @Override
+    public String getClassName( final ConstantPoolGen cpg ) {
+        final ConstantPool cp = cpg.getConstantPool();
+        final ConstantCP cmr = (ConstantCP) cp.getConstant(super.getIndex());
+        final String className = cp.getConstantString(cmr.getClassIndex(), Const.CONSTANT_Class);
+        if (className.startsWith("[")) {
+            throw new IllegalArgumentException("Cannot be used on an array type");
+        }
+        return className.replace('/', '.');
+    }
 
     /** @return return type of referenced method.
      */


### PR DESCRIPTION
BCEL-262: InvokeInstruction.getClassName(ConstantPoolGen) should throw an exception when it detects an array. Thanks to Mark Roberts.  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1751083 13f79535-47bb-0310-9956-ffa450edef68
