### PR TITLE
[BCEL-326] Add missing Java 9 and Java 11 class file attributes [judge]

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -74,6 +74,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="BCEL-270" type="fix" dev="ggregory" due-to="Alexandru-Constantin Bledea">Calling toString(ConstantPool) on InvokeInstruction throws NullPointerException.</action>
       <action issue="BCEL-321" type="add" dev="ggregory" due-to="Tomo Suzuki">Refactor subclasses of ClassPathRepository for differences in underlying cache.</action>
       <action issue="BCEL-323" type="fix" dev="ggregory" due-to="Tomo Suzuki">org.apache.bcel.util.BCELifier to set major and minor versions.</action>
+      <action issue="BCEL-326" type="fix" dev="ggregory" due-to="TMark Roberts">Add missing Java 9 and Java 11 class file attributes. #33</action>
     </release>
 
     <release version="6.3.1" date="2019-03-20" description="Bug fix release">

--- a/src/main/java/org/apache/bcel/classfile/DescendingVisitor.java
+++ b/src/main/java/org/apache/bcel/classfile/DescendingVisitor.java
@@ -508,7 +508,7 @@ public class DescendingVisitor implements Visitor
     }
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     @Override
     public void visitMethodParameter(final MethodParameter obj)
@@ -566,7 +566,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModule(final Module obj) {
         stack.push(obj);
@@ -592,7 +592,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleRequires(final ModuleRequires obj) {
         stack.push(obj);
@@ -600,7 +600,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleExports(final ModuleExports obj) {
         stack.push(obj);
@@ -608,7 +608,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleOpens(final ModuleOpens obj) {
         stack.push(obj);
@@ -616,7 +616,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleProvides(final ModuleProvides obj) {
         stack.push(obj);
@@ -624,7 +624,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModulePackages(final ModulePackages obj) {
         stack.push(obj);
@@ -632,7 +632,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleMainClass(final ModuleMainClass obj) {
         stack.push(obj);
@@ -640,7 +640,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitNestHost(final NestHost obj) {
         stack.push(obj);
@@ -648,7 +648,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitNestMembers(final NestMembers obj) {
         stack.push(obj);

--- a/src/main/java/org/apache/bcel/classfile/EmptyVisitor.java
+++ b/src/main/java/org/apache/bcel/classfile/EmptyVisitor.java
@@ -275,7 +275,7 @@ public class EmptyVisitor implements Visitor
     }
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     @Override
     public void visitMethodParameter(final MethodParameter obj)
@@ -325,47 +325,47 @@ public class EmptyVisitor implements Visitor
     public void visitConstantDynamic(final ConstantDynamic obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModule(final Module obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleRequires(final ModuleRequires obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleExports(final ModuleExports obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleOpens(final ModuleOpens obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleProvides(final ModuleProvides obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModulePackages(final ModulePackages obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleMainClass(final ModuleMainClass obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitNestHost(final NestHost obj) {
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitNestMembers(final NestMembers obj) {
     }

--- a/src/main/java/org/apache/bcel/classfile/Module.java
+++ b/src/main/java/org/apache/bcel/classfile/Module.java
@@ -28,7 +28,7 @@ import org.apache.bcel.Const;
  * There may be at most one Module attribute in a ClassFile structure.
  *
  * @see   Attribute
- * @since 6.4
+ * @since 6.4.0
  */
 public final class Module extends Attribute {
 

--- a/src/main/java/org/apache/bcel/classfile/ModuleExports.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleExports.java
@@ -28,7 +28,7 @@ import org.apache.bcel.Const;
  * Each entry describes a package which may open the parent module.
  *
  * @see   Module
- * @since 6.4
+ * @since 6.4.0
  */
 public final class ModuleExports implements Cloneable, Node {
 

--- a/src/main/java/org/apache/bcel/classfile/ModuleOpens.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleOpens.java
@@ -28,7 +28,7 @@ import org.apache.bcel.Const;
  * Each entry describes a package which the parent module opens.
  *
  * @see   Module
- * @since 6.4
+ * @since 6.4.0
  */
 public final class ModuleOpens implements Cloneable, Node {
 

--- a/src/main/java/org/apache/bcel/classfile/ModuleProvides.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleProvides.java
@@ -28,7 +28,7 @@ import org.apache.bcel.Const;
  * Each entry describes a service implementation that the parent module provides.
  *
  * @see   Module
- * @since 6.4
+ * @since 6.4.0
  */
 public final class ModuleProvides implements Cloneable, Node {
 

--- a/src/main/java/org/apache/bcel/classfile/ModuleRequires.java
+++ b/src/main/java/org/apache/bcel/classfile/ModuleRequires.java
@@ -28,7 +28,7 @@ import org.apache.bcel.Const;
  * Each entry describes a module on which the parent module depends.
  *
  * @see   Module
- * @since 6.4
+ * @since 6.4.0
  */
 public final class ModuleRequires implements Cloneable, Node {
 

--- a/src/main/java/org/apache/bcel/classfile/Visitor.java
+++ b/src/main/java/org/apache/bcel/classfile/Visitor.java
@@ -132,7 +132,7 @@ public interface Visitor
     void visitMethodParameters(MethodParameters obj);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     default void visitMethodParameter(MethodParameter obj) {
         // empty
@@ -171,47 +171,47 @@ public interface Visitor
     }
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitModule(Module constantModule);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitModuleRequires(ModuleRequires constantModule);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitModuleExports(ModuleExports constantModule);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitModuleOpens(ModuleOpens constantModule);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitModuleProvides(ModuleProvides constantModule);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitModulePackages(ModulePackages constantModule);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitModuleMainClass(ModuleMainClass obj);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitNestHost(NestHost obj);
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     void visitNestMembers(NestMembers obj);
 }

--- a/src/main/java/org/apache/bcel/verifier/statics/StringRepresentation.java
+++ b/src/main/java/org/apache/bcel/verifier/statics/StringRepresentation.java
@@ -406,7 +406,7 @@ public class StringRepresentation extends org.apache.bcel.classfile.EmptyVisitor
     }
 
     /**
-     * @since 6.4
+     * @since 6.4.0
      */
     @Override
     public void visitNestMembers(final NestMembers obj) {

--- a/src/test/java/org/apache/bcel/visitors/CounterVisitor.java
+++ b/src/test/java/org/apache/bcel/visitors/CounterVisitor.java
@@ -177,31 +177,31 @@ public class CounterVisitor implements Visitor
     /** @since 6.3 */
     public int constantDynamicCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int moduleCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int moduleExportsCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int moduleOpensCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int moduleProvidesCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int moduleRequiresCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int moduleMainClassCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int modulePackagesCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int nestHostCount = 0;
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     public int nestMembersCount = 0;
     // CHECKSTYLE:ON
 
@@ -498,55 +498,55 @@ public class CounterVisitor implements Visitor
         constantDynamicCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModule(final Module obj) {
         moduleCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleExports(final ModuleExports obj) {
         moduleExportsCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleOpens(final ModuleOpens obj) {
         moduleOpensCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleProvides(final ModuleProvides obj) {
         moduleProvidesCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleRequires(final ModuleRequires obj) {
         moduleRequiresCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModuleMainClass(final ModuleMainClass obj) {
         moduleMainClassCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitModulePackages(final ModulePackages obj) {
         modulePackagesCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitNestHost(final NestHost obj) {
         nestHostCount++;
     }
 
-    /** @since 6.4 */
+    /** @since 6.4.0 */
     @Override
     public void visitNestMembers(final NestMembers obj) {
         nestMembersCount++;


### PR DESCRIPTION
[BCEL-326] Add missing Java 9 and Java 11 class file attributes. #33.  Use @since 6.4.0 instead of 6.4.
