### PR TITLE
Javadoc: Use file name instead of filename. [Judge]

### DIFF
--- a/src/examples/ClassDumper.java
+++ b/src/examples/ClassDumper.java
@@ -350,7 +350,7 @@ class DumpClass {
     public static void main (String[] args) throws IOException {
 
         if (args.length != 1) {
-            throw new RuntimeException("Require filename as only argument");
+            throw new RuntimeException("Require file name as only argument");
         }
 
         FileImageInputStream file = new FileImageInputStream(new File(args[0]));

--- a/src/main/java/org/apache/bcel/classfile/JavaClass.java
+++ b/src/main/java/org/apache/bcel/classfile/JavaClass.java
@@ -611,7 +611,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
             }
             buf.append('\n');
         }
-        buf.append("filename\t\t").append(file_name).append('\n');
+        buf.append("file name\t\t").append(file_name).append('\n');
         buf.append("compiled from\t\t").append(source_file_name).append('\n');
         buf.append("compiler version\t").append(major).append(".").append(minor).append('\n');
         buf.append("access flags\t\t").append(super.getAccessFlags()).append('\n');

--- a/src/main/java/org/apache/bcel/verifier/statics/Pass2Verifier.java
+++ b/src/main/java/org/apache/bcel/verifier/statics/Pass2Verifier.java
@@ -835,16 +835,16 @@ public final class Pass2Verifier extends PassVerifier implements Constants {
 
             checkIndex(obj, obj.getSourceFileIndex(), CONST_Utf8);
 
-            final String sourcefilename = ((ConstantUtf8) cp.getConstant(obj.getSourceFileIndex())).getBytes(); //==obj.getSourceFileName() ?
-            final String sourcefilenamelc = sourcefilename.toLowerCase(Locale.ENGLISH);
+            final String sourceFileName = ((ConstantUtf8) cp.getConstant(obj.getSourceFileIndex())).getBytes(); //==obj.getSourceFileName() ?
+            final String sourceFileNameLc = sourceFileName.toLowerCase(Locale.ENGLISH);
 
-            if (    (sourcefilename.indexOf('/') != -1) ||
-                        (sourcefilename.indexOf('\\') != -1) ||
-                        (sourcefilename.indexOf(':') != -1) ||
-                        (sourcefilenamelc.lastIndexOf(".java") == -1)    ) {
+            if (    (sourceFileName.indexOf('/') != -1) ||
+                        (sourceFileName.indexOf('\\') != -1) ||
+                        (sourceFileName.indexOf(':') != -1) ||
+                        (sourceFileNameLc.lastIndexOf(".java") == -1)    ) {
                 addMessage("SourceFile attribute '"+tostring(obj)+
                     "' has a funny name: remember not to confuse certain parsers working on javap's output. Also, this name ('"+
-                    sourcefilename+"') is considered an unqualified (simple) file name only.");
+                    sourceFileName+"') is considered an unqualified (simple) file name only.");
             }
         }
         @Override


### PR DESCRIPTION
Javadoc: Use file name instead of filename.  Camel case vars filename to fileName.
