### PR TITLE
First pass at Java 11 support based on EA releases [judge]

### DIFF
--- a/src/main/java/org/apache/bcel/Const.java
+++ b/src/main/java/org/apache/bcel/Const.java
@@ -385,6 +385,14 @@ public final class Const {
   public static final byte CONSTANT_MethodType         = 16;
 
   /**
+   * Marks a constant pool entry as dynamically computed.
+   * @see  <a href="https://bugs.openjdk.java.net/secure/attachment/74618/constant-dynamic.html">
+   * Change request for JEP 309</a>
+   * @since 6.3
+   */
+  public static final byte CONSTANT_Dynamic            = 17;
+
+  /**
    * Marks a constant pool entry as an Invoke Dynamic
    * @see  <a href="http://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.4.10">
    * The Constant Pool in The Java Virtual Machine Specification</a>
@@ -417,7 +425,7 @@ public final class Const {
     "CONSTANT_Class", "CONSTANT_String", "CONSTANT_Fieldref",
     "CONSTANT_Methodref", "CONSTANT_InterfaceMethodref",
     "CONSTANT_NameAndType", "", "", "CONSTANT_MethodHandle",
-    "CONSTANT_MethodType", "", "CONSTANT_InvokeDynamic",
+    "CONSTANT_MethodType", "CONSTANT_Dynamic", "CONSTANT_InvokeDynamic",
     "CONSTANT_Module", "CONSTANT_Package"};
 
   /**

--- a/src/main/java/org/apache/bcel/classfile/Constant.java
+++ b/src/main/java/org/apache/bcel/classfile/Constant.java
@@ -162,6 +162,8 @@ public abstract class Constant implements Cloneable, Node {
             return new ConstantMethodHandle(dataInput);
         case Const.CONSTANT_MethodType:
             return new ConstantMethodType(dataInput);
+        case Const.CONSTANT_Dynamic:
+            return new ConstantDynamic(dataInput);
         case Const.CONSTANT_InvokeDynamic:
             return new ConstantInvokeDynamic(dataInput);
         case Const.CONSTANT_Module:

--- a/src/main/java/org/apache/bcel/classfile/ConstantDynamic.java
+++ b/src/main/java/org/apache/bcel/classfile/ConstantDynamic.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.apache.bcel.classfile;
+
+import java.io.DataInput;
+import java.io.IOException;
+
+import org.apache.bcel.Const;
+
+/**
+ * This class is derived from the abstract {@link Constant}
+ * and represents a reference to a dynamically computed constant.
+ *
+ * @see     Constant
+ * @see  <a href="https://bugs.openjdk.java.net/secure/attachment/74618/constant-dynamic.html">
+ * Change request for JEP 309</a>
+ * @since 6.3
+ */
+public final class ConstantDynamic extends ConstantCP {
+
+    /**
+     * Initialize from another object.
+     */
+    public ConstantDynamic(final ConstantDynamic c) {
+        this(c.getBootstrapMethodAttrIndex(), c.getNameAndTypeIndex());
+    }
+
+
+    /**
+     * Initialize instance from file data.
+     *
+     * @param file Input stream
+     * @throws IOException
+     */
+    ConstantDynamic(final DataInput file) throws IOException {
+        this(file.readShort(), file.readShort());
+    }
+
+
+    public ConstantDynamic(final int bootstrap_method_attr_index, final int name_and_type_index) {
+        super(Const.CONSTANT_Dynamic, bootstrap_method_attr_index, name_and_type_index);
+    }
+
+
+    /**
+     * Called by objects that are traversing the nodes of the tree implicitly
+     * defined by the contents of a Java class. I.e., the hierarchy of methods,
+     * fields, attributes, etc. spawns a tree of objects.
+     *
+     * @param v Visitor object
+     */
+    @Override
+    public void accept( final Visitor v ) {
+        v.visitConstantDynamic(this);
+    }
+
+    /**
+     * @return Reference (index) to bootstrap method this constant refers to.
+     *
+     * Note that this method is a functional duplicate of getClassIndex
+     * for use by ConstantInvokeDynamic.
+     * @since 6.0
+     */
+    public final int getBootstrapMethodAttrIndex() {
+        return super.getClassIndex();  // AKA bootstrap_method_attr_index
+    }
+
+    /**
+     * @return String representation
+     */
+    @Override
+    public final String toString() {
+        return super.toString().replace("class_index", "bootstrap_method_attr_index");
+    }
+}

--- a/src/main/java/org/apache/bcel/classfile/DescendingVisitor.java
+++ b/src/main/java/org/apache/bcel/classfile/DescendingVisitor.java
@@ -543,4 +543,12 @@ public class DescendingVisitor implements Visitor
         obj.accept(visitor);
         stack.pop();
     }
+
+    /** @since 6.3 */
+    @Override
+    public void visitConstantDynamic(final ConstantDynamic obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
 }

--- a/src/main/java/org/apache/bcel/classfile/EmptyVisitor.java
+++ b/src/main/java/org/apache/bcel/classfile/EmptyVisitor.java
@@ -310,4 +310,12 @@ public class EmptyVisitor implements Visitor
     @Override
     public void visitConstantModule(final ConstantModule constantModule) {
     }
+
+
+    /**
+     * @since 6.3
+     */
+    @Override
+    public void visitConstantDynamic(final ConstantDynamic obj) {
+    }
 }

--- a/src/main/java/org/apache/bcel/classfile/Visitor.java
+++ b/src/main/java/org/apache/bcel/classfile/Visitor.java
@@ -156,4 +156,9 @@ public interface Visitor
      * @since 6.1
      */
     void visitConstantModule(ConstantModule constantModule);
+
+    /**
+     * @since 6.3
+     */
+    void visitConstantDynamic(ConstantDynamic constantDynamic);
 }

--- a/src/test/java/org/apache/bcel/visitors/CounterVisitor.java
+++ b/src/test/java/org/apache/bcel/visitors/CounterVisitor.java
@@ -26,6 +26,7 @@ import org.apache.bcel.classfile.Code;
 import org.apache.bcel.classfile.CodeException;
 import org.apache.bcel.classfile.ConstantClass;
 import org.apache.bcel.classfile.ConstantDouble;
+import org.apache.bcel.classfile.ConstantDynamic;
 import org.apache.bcel.classfile.ConstantFieldref;
 import org.apache.bcel.classfile.ConstantFloat;
 import org.apache.bcel.classfile.ConstantInteger;
@@ -159,6 +160,9 @@ public class CounterVisitor implements Visitor
 
     /** @since 6.1 */
     public int constantPackageCount = 0;
+
+    /** @since 6.3 */
+    public int constantDynamicCount = 0;
     // CHECKSTYLE:ON
 
 
@@ -439,5 +443,11 @@ public class CounterVisitor implements Visitor
     @Override
     public void visitConstantModule(final ConstantModule constantModule) {
         constantModuleCount++;
+    }
+
+    /** @since 6.3 */
+    @Override
+    public void visitConstantDynamic(final ConstantDynamic constantDynamic) {
+        constantDynamicCount++;
     }
 }


### PR DESCRIPTION
First pass at Java 11 support based on EA releases and https://bugs.openjdk.java.net/browse/JDK-8189199  The implementation is far from complete. The motivation is primarily to provide the minimum required by Tomcat to parse Java 11 class files.  I have assumed (early access) Java 11 support will make the next release (6.3).  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1829452 13f79535-47bb-0310-9956-ffa450edef68
