### PR TITLE
BCEL-264 Add missing Node.accept() implementations [judge]

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -63,7 +63,8 @@ The <action> type attribute can be add,update,fix,remove.
 
   <body>
     <release version="6.0" date="TBA" description="Major release with Java 7 and 8 support">
-      <action issue="BCEL-221" type="fix">BCELifier is not working for Java8Example</action>
+      <action issue="BCEL-264" type="fix">Add missing Node.accept() implementations (ConstantMethodHandle, ConstantMethodType, ParameterAnnotationEntry)</action>
+      <action issue="BCEL-221" type="fix">BCELifier is not working for Java8Example (incomplete)</action>
       <action issue="BCEL-195" type="fix">addition of hashCode() to generic/Instruction.java breaks Targeters. Never make distinct BranchInstructions compare equal</action>
       <action issue="BCEL-261" type="fix">Select constructor allows partially constructed instance to escape. Re-ordered code to delay the escape.</action>
       <action issue="BCEL-259" type="fix">Minor doc error in BranchInstruction.java</action>

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantMethodHandle.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantMethodHandle.java
@@ -71,7 +71,7 @@ public final class ConstantMethodHandle extends Constant {
      */
     @Override
     public void accept( Visitor v ) {
-        // TODO Add .visitMethodHandle to Visitor interface
+        v.visitConstantMethodHandle(this);
     }
 
 

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantMethodType.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantMethodType.java
@@ -69,7 +69,7 @@ public final class ConstantMethodType extends Constant {
      */
     @Override
     public void accept( Visitor v ) {
-        // TODO Add .visitMethodType to Visitor interface
+        v.visitConstantMethodType(this);
     }
 
 

--- a/src/main/java/org/apache/commons/bcel6/classfile/DescendingVisitor.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/DescendingVisitor.java
@@ -529,4 +529,29 @@ public class DescendingVisitor implements Visitor
         obj.accept(visitor);
         stack.pop();
     }
+
+    /** @since 6.0 */
+    @Override
+    public void visitConstantMethodType(ConstantMethodType obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.0 */
+    @Override
+    public void visitConstantMethodHandle(ConstantMethodHandle obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
+    /** @since 6.0 */
+    @Override
+    public void visitParameterAnnotationEntry(ParameterAnnotationEntry obj) {
+        stack.push(obj);
+        obj.accept(visitor);
+        stack.pop();
+    }
+
 }

--- a/src/main/java/org/apache/commons/bcel6/classfile/EmptyVisitor.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/EmptyVisitor.java
@@ -274,4 +274,26 @@ public class EmptyVisitor implements Visitor
     public void visitMethodParameters(MethodParameters obj)
     {
     }
+
+    /**
+     * @since 6.0
+     */
+    @Override
+    public void visitConstantMethodType(ConstantMethodType obj)
+    {
+    }
+
+    /**
+     * @since 6.0
+     */
+    @Override
+    public void visitConstantMethodHandle(ConstantMethodHandle constantMethodHandle) {
+    }
+
+    /**
+     * @since 6.0
+     */
+    @Override
+    public void visitParameterAnnotationEntry(ParameterAnnotationEntry parameterAnnotationEntry) {
+    }
 }

--- a/src/main/java/org/apache/commons/bcel6/classfile/ParameterAnnotationEntry.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ParameterAnnotationEntry.java
@@ -60,7 +60,7 @@ public class ParameterAnnotationEntry implements Node {
      */
     @Override
     public void accept( Visitor v ) {
-        // v.visitParameterAnnotationEntry(this);
+        v.visitParameterAnnotationEntry(this);
     }
 
     /**

--- a/src/main/java/org/apache/commons/bcel6/classfile/Visitor.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Visitor.java
@@ -131,4 +131,19 @@ public interface Visitor
      * @since 6.0
      */
     void visitMethodParameters(MethodParameters obj);
+
+    /**
+     * @since 6.0
+     */
+    void visitConstantMethodType(ConstantMethodType obj);
+
+    /**
+     * @since 6.0
+     */
+    void visitConstantMethodHandle(ConstantMethodHandle obj);
+
+    /**
+     * @since 6.0
+     */
+    void visitParameterAnnotationEntry(ParameterAnnotationEntry obj);
 }

--- a/src/test/java/org/apache/commons/bcel6/visitors/CounterVisitor.java
+++ b/src/test/java/org/apache/commons/bcel6/visitors/CounterVisitor.java
@@ -32,6 +32,8 @@ import org.apache.commons.bcel6.classfile.ConstantInteger;
 import org.apache.commons.bcel6.classfile.ConstantInterfaceMethodref;
 import org.apache.commons.bcel6.classfile.ConstantInvokeDynamic;
 import org.apache.commons.bcel6.classfile.ConstantLong;
+import org.apache.commons.bcel6.classfile.ConstantMethodHandle;
+import org.apache.commons.bcel6.classfile.ConstantMethodType;
 import org.apache.commons.bcel6.classfile.ConstantMethodref;
 import org.apache.commons.bcel6.classfile.ConstantNameAndType;
 import org.apache.commons.bcel6.classfile.ConstantPool;
@@ -52,6 +54,7 @@ import org.apache.commons.bcel6.classfile.LocalVariableTable;
 import org.apache.commons.bcel6.classfile.LocalVariableTypeTable;
 import org.apache.commons.bcel6.classfile.Method;
 import org.apache.commons.bcel6.classfile.MethodParameters;
+import org.apache.commons.bcel6.classfile.ParameterAnnotationEntry;
 import org.apache.commons.bcel6.classfile.ParameterAnnotations;
 import org.apache.commons.bcel6.classfile.Signature;
 import org.apache.commons.bcel6.classfile.SourceFile;
@@ -398,5 +401,23 @@ public class CounterVisitor implements Visitor
     public void visitConstantInvokeDynamic(ConstantInvokeDynamic obj)
     {
         constantInvokeDynamic++;
+    }
+
+    /** @since 6.0 */
+    @Override
+    public void visitConstantMethodType(ConstantMethodType obj) {
+        // TODO Auto-generated method stub        
+    }
+
+    /** @since 6.0 */
+    @Override
+    public void visitConstantMethodHandle(ConstantMethodHandle constantMethodHandle) {
+        // TODO Auto-generated method stub
+    }
+
+    /** @since 6.0 */
+    @Override
+    public void visitParameterAnnotationEntry(ParameterAnnotationEntry parameterAnnotationEntry) {
+        // TODO Auto-generated method stub        
     }
 }


### PR DESCRIPTION
BCEL-264 Add missing Node.accept() implementations (ConstantMethodHandle  ConstantMethodType  ParameterAnnotationEntry)  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1702615 13f79535-47bb-0310-9956-ffa450edef68
