### PR TITLE
BCEL-221 BCELifier is not working for Java8Example [judge]

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -63,6 +63,7 @@ The <action> type attribute can be add,update,fix,remove.
 
   <body>
     <release version="6.0" date="TBA" description="Major release with Java 7 and 8 support">
+      <action issue="BCEL-221" type="fix">BCELifier is not working for Java8Example</action>
       <action issue="BCEL-195" type="fix">addition of hashCode() to generic/Instruction.java breaks Targeters. Never make distinct BranchInstructions compare equal</action>
       <action issue="BCEL-261" type="fix">Select constructor allows partially constructed instance to escape. Re-ordered code to delay the escape.</action>
       <action issue="BCEL-259" type="fix">Minor doc error in BranchInstruction.java</action>

--- a/src/main/java/org/apache/commons/bcel6/generic/INVOKEDYNAMIC.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/INVOKEDYNAMIC.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 import org.apache.commons.bcel6.Const;
 import org.apache.commons.bcel6.ExceptionConst;
+import org.apache.commons.bcel6.classfile.ConstantInvokeDynamic;
+import org.apache.commons.bcel6.classfile.ConstantNameAndType;
 import org.apache.commons.bcel6.classfile.ConstantPool;
 import org.apache.commons.bcel6.util.ByteSequence;
 
@@ -114,5 +116,14 @@ public class INVOKEDYNAMIC extends InvokeInstruction {
         v.visitFieldOrMethod(this);
         v.visitInvokeInstruction(this);
         v.visitINVOKEDYNAMIC(this);
+    }
+
+    /**
+     * Override the parent method because our classname is held elsewhere.
+     */
+    public String getClassName( ConstantPoolGen cpg ) {
+        ConstantPool cp = cpg.getConstantPool();
+        ConstantInvokeDynamic cid = (ConstantInvokeDynamic) cp.getConstant(super.getIndex(), Const.CONSTANT_InvokeDynamic);
+        return ((ConstantNameAndType) cp.getConstant(cid.getNameAndTypeIndex())).getName(cp);
     }
 }

--- a/src/test/java/org/apache/commons/bcel6/util/BCELifierTestCase.java
+++ b/src/test/java/org/apache/commons/bcel6/util/BCELifierTestCase.java
@@ -2,21 +2,20 @@ package org.apache.commons.bcel6.util;
 
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+
 import org.apache.commons.bcel6.classfile.JavaClass;
 import org.junit.Test;
-import static org.junit.Assume.assumeTrue;
 
 public class BCELifierTestCase {
 
-    // A bit of a hack - we use the same property as for the perf test for now
-    private static final boolean REPORT = Boolean.parseBoolean(System.getProperty("PerformanceTest.report", "true"));;
-
     @Test
     public void test() throws Exception {
-        assumeTrue(REPORT); // set to false by pom so this will only run on demand
+        OutputStream os = new ByteArrayOutputStream();
         JavaClass java_class = BCELifier.getJavaClass("Java8Example");
         assertNotNull(java_class);
-        BCELifier bcelifier = new BCELifier(java_class, System.out);
+        BCELifier bcelifier = new BCELifier(java_class, os);
         bcelifier.start();
     }
 


### PR DESCRIPTION
BCEL-221 BCELifier is not working for Java8Example Workround for crash; may need further work  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1702447 13f79535-47bb-0310-9956-ffa450edef68
