### PR TITLE
Add deprecated markers to non-private mutable fields [judge]

### DIFF
--- a/src/main/java/org/apache/commons/bcel6/generic/BranchInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/BranchInstruction.java
@@ -32,8 +32,22 @@ import org.apache.commons.bcel6.util.ByteSequence;
  */
 public abstract class BranchInstruction extends Instruction implements InstructionTargeter {
 
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int index; // Branch target relative to this instruction
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected InstructionHandle target; // Target object in instruction list
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int position; // Byte code offset
 
 

--- a/src/main/java/org/apache/commons/bcel6/generic/ConstantPoolGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ConstantPoolGen.java
@@ -53,9 +53,25 @@ import org.apache.commons.bcel6.classfile.ConstantUtf8;
 public class ConstantPoolGen {
 
     private static final int DEFAULT_BUFFER_SIZE = 256;
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int size; 
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected Constant[] constants;
+
+    /**
+     * @deprecated will be made private; do not access directly, use getSize()
+     */
+    @Deprecated
     protected int index = 1; // First entry (0) used by JVM
+
     private static final String METHODREF_DELIM = ":";
     private static final String IMETHODREF_DELIM = "#";
     private static final String FIELDREF_DELIM = "&";

--- a/src/main/java/org/apache/commons/bcel6/generic/ElementValueGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ElementValueGen.java
@@ -34,8 +34,16 @@ import org.apache.commons.bcel6.classfile.SimpleElementValue;
  */
 public abstract class ElementValueGen
 {
+    /**
+     * @deprecated will be made private and final; do not access directly, use getter
+     */
+    @Deprecated
     protected int type;
 
+    /**
+     * @deprecated will be made private and final; do not access directly, use getter
+     */
+    @Deprecated
     protected ConstantPoolGen cpGen;
 
     protected ElementValueGen(int type, ConstantPoolGen cpGen)

--- a/src/main/java/org/apache/commons/bcel6/generic/FieldGenOrMethodGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FieldGenOrMethodGen.java
@@ -32,10 +32,26 @@ import org.apache.commons.bcel6.classfile.Attribute;
  */
 public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAndTyped, Cloneable {
 
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected String name;
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected Type type;
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected ConstantPoolGen cp;
+
     private final List<Attribute> attribute_vec = new ArrayList<>();
+
     // @since 6.0
     private final List<AnnotationEntryGen>       annotation_vec= new ArrayList<>();
 

--- a/src/main/java/org/apache/commons/bcel6/generic/Instruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/Instruction.java
@@ -31,8 +31,18 @@ import org.apache.commons.bcel6.util.ByteSequence;
  */
 public abstract class Instruction implements Cloneable {
 
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected short length = 1; // Length of instruction in bytes 
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected short opcode = -1; // Opcode number
+
     private static InstructionComparator cmp = InstructionComparator.DEFAULT;
 
 
@@ -505,8 +515,17 @@ public abstract class Instruction implements Cloneable {
     /**
      * Needed in readInstruction and subclasses in this package
      */
-    void setOpcode( short opcode ) {
+    final void setOpcode( short opcode ) {
         this.opcode = opcode;
+    }
+
+
+    /**
+     * Needed in readInstruction and subclasses in this package
+     * @since 6.0
+     */
+    final void setLength( int length ) {
+        this.length = (short) length; // TODO check range?
     }
 
 

--- a/src/main/java/org/apache/commons/bcel6/generic/InstructionFactory.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/InstructionFactory.java
@@ -39,7 +39,16 @@ public class InstructionFactory {
             "C", "F", "D", "B", "S", "I", "L"
     };
 
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected ClassGen cg;
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected ConstantPoolGen cp;
 
 

--- a/src/main/java/org/apache/commons/bcel6/generic/InstructionHandle.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/InstructionHandle.java
@@ -44,10 +44,17 @@ import org.apache.commons.bcel6.classfile.Utility;
  */
 public class InstructionHandle {
 
+    // TODO make private
     InstructionHandle next;
-    InstructionHandle prev; // Will be set from the outside
+    InstructionHandle prev;
     Instruction instruction;
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int i_position = -1; // byte code offset of instruction
+
     private Set<InstructionTargeter> targeters;
     private Map<Object, Object> attributes;
 
@@ -288,5 +295,25 @@ public class InstructionHandle {
      */
     public void accept( Visitor v ) {
         instruction.accept(v);
+    }
+
+
+    /**
+     * @param next the next to set
+     * @ since 6.0
+     */
+    final InstructionHandle setNext(InstructionHandle next) {
+        this.next = next;
+        return next;
+    }
+
+
+    /**
+     * @param prev the prev to set
+     * @ since 6.0
+     */
+    final InstructionHandle setPrev(InstructionHandle prev) {
+        this.prev = prev;
+        return prev;
     }
 }

--- a/src/main/java/org/apache/commons/bcel6/generic/LocalVariableInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LocalVariableInstruction.java
@@ -31,7 +31,12 @@ import org.apache.commons.bcel6.util.ByteSequence;
 public abstract class LocalVariableInstruction extends Instruction implements TypedInstruction,
         IndexedInstruction {
 
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int n = -1; // index of referenced variable
+
     private short c_tag = -1; // compact version, such as ILOAD_0
     private short canon_tag = -1; // canonical tag such as ILOAD
 
@@ -139,7 +144,7 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
 
 
     /**
-     * @return local variable index  referred by this instruction.
+     * @return local variable index (n) referred by this instruction.
      */
     @Override
     public final int getIndex() {

--- a/src/main/java/org/apache/commons/bcel6/generic/Select.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/Select.java
@@ -35,11 +35,40 @@ import org.apache.commons.bcel6.util.ByteSequence;
 public abstract class Select extends BranchInstruction implements VariableLengthInstruction,
         StackConsumer /* @since 6.0 */, StackProducer {
 
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int[] match; // matches, i.e., case 1: ... TODO could be package-protected?
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int[] indices; // target offsets TODO could be package-protected?
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected InstructionHandle[] targets; // target objects in instruction list TODO could be package-protected?
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int fixed_length; // fixed length defined by subclasses TODO could be package-protected?
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int match_length; // number of cases TODO could be package-protected?
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected int padding = 0; // number of pad bytes for alignment TODO could be package-protected?
 
 
@@ -242,5 +271,120 @@ public abstract class Select extends BranchInstruction implements VariableLength
      */
     public InstructionHandle[] getTargets() {
         return targets;
+    }
+
+    /**
+     * @return match entry
+     * @since 6.0
+     */
+    final int getMatch(int index) {
+        return match[index];
+    }
+
+
+    /**
+     * @return index entry from indices
+     * @since 6.0
+     */
+    final int getIndices(int index) {
+        return indices[index];
+    }
+
+    /**
+     * @return target entry
+     * @since 6.0
+     */
+    final InstructionHandle getTarget(int index) {
+        return targets[index];
+    }
+
+
+    /**
+     * @return the fixed_length
+     * @since 6.0
+     */
+    final int getFixed_length() {
+        return fixed_length;
+    }
+
+
+    /**
+     * @param fixed_length the fixed_length to set
+     * @since 6.0
+     */
+    final void setFixed_length(int fixed_length) {
+        this.fixed_length = fixed_length;
+    }
+
+
+    /**
+     * @return the match_length
+     * @since 6.0
+     */
+    final int getMatch_length() {
+        return match_length;
+    }
+
+
+    /**
+     * @param match_length the match_length to set
+     * @since 6.0
+     */
+    final int setMatch_length(int match_length) {
+        this.match_length = match_length;
+        return match_length;
+    }
+    
+    /**
+     * 
+     * @param index
+     * @param value
+     * @since 6.0
+     */
+    final void setMatch(int index, int value) {
+        match[index] = value;
+    }
+    
+    /**
+     * 
+     * @param array
+     * @since 6.0
+     */
+    final void setIndices(int[] array) {
+        indices = array;
+    }
+    
+    /**
+     * 
+     * @param array
+     * @since 6.0
+     */
+    final void setMatches(int[] array) {
+        match = array;
+    }
+    
+    /**
+     * 
+     * @param array
+     * @since 6.0
+     */
+    final void setTargets(InstructionHandle[] array) {
+        targets = array;
+    }
+    
+    /**
+     * 
+     * @return
+     * @since 6.0
+     */
+    final int getPadding() {
+        return padding;
+    }
+
+
+    /** @since 6.0 */
+    final int setIndices(int i, int value) {
+        indices[i] = value;
+        return value;  // Allow use in nested calls
     }
 }

--- a/src/main/java/org/apache/commons/bcel6/generic/Type.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/Type.java
@@ -32,7 +32,16 @@ import org.apache.commons.bcel6.classfile.Utility;
  */
 public abstract class Type {
 
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected byte type; // TODO should be final (and private)
+
+    /**
+     * @deprecated will be made private; do not access directly, use getter/setter
+     */
+    @Deprecated
     protected String signature; // signature for the type TODO should be private
     /** Predefined constants
      */

--- a/src/main/java/org/apache/commons/bcel6/util/ClassQueue.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassQueue.java
@@ -29,7 +29,11 @@ import org.apache.commons.bcel6.classfile.JavaClass;
  */
 public class ClassQueue {
 
-    protected LinkedList<JavaClass> vec = new LinkedList<>();
+    /**
+     * @deprecated will be made private; do not access
+     */
+    @Deprecated
+    protected LinkedList<JavaClass> vec = new LinkedList<>(); // TODO not used externally
 
 
     public void enqueue( JavaClass clazz ) {

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/Frame.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/Frame.java
@@ -33,9 +33,10 @@ public class Frame{
      * which instance it is that is not initialized yet. It will be
      * initialized invoking another constructor later.
      * NULL means the instance already *is* initialized.
-     * N.B. Use the getter/setter to access the field as it may
+     * @deprecated Use the getter/setter to access the field as it may
      * be made private in a later release
      */
+    @Deprecated
     protected static UninitializedObjectType _this;
 
     /**


### PR DESCRIPTION
Add deprecated markers to non-private mutable fields so usage is detected Add getters/setters as necessary to give access  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1697695 13f79535-47bb-0310-9956-ffa450edef68
