### PR TITLE
BCEL-110 Problem with JAXB if the bcel classloader is used

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -64,7 +64,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
     <release version="6.0" date="TBA" description="Major release with Java 7 and 8 support">
       <action issue="BCEL-231" type="remove">Remove deprecated methods and classes</action>
-      <action issue="BCEL-110" type="remove">Problem with JAXB if the bcel classloader is used</action>
+      <action issue="BCEL-110" type="remove">Problem with JAXB if the bcel classloader is used; remove the broken ClassLoader class</action>
       <action issue="BCEL-201" type="update">modify several toString methods to make output similar to "javap"</action>
       <action issue="BCEL-205" type="update">add javadoc comments to LineNumber.java and LineNumberTable.java</action>
       <action issue="BCEL-208" type="fix">Need to check for an empty InstructionList</action>

--- a/src/main/java/org/apache/commons/bcel6/util/JavaWrapper.java
+++ b/src/main/java/org/apache/commons/bcel6/util/JavaWrapper.java
@@ -28,8 +28,7 @@ import java.lang.reflect.Modifier;
  * 
  * <pre>java org.apache.commons.bcel6.util.JavaWrapper &lt;real.class.name&gt; [arguments]</pre>
  * 
- * <p>To use your own class loader you can set the "bcel.classloader" system property
- * which defaults to "org.apache.commons.bcel6.util.ClassLoader", e.g., with:</p>
+ * <p>To use your own class loader you can set the "bcel.classloader" system property<p>
  * <pre>java org.apache.commons.bcel6.util.JavaWrapper -Dbcel.classloader=foo.MyLoader &lt;real.class.name&gt; [arguments]</pre>
  *
  * @version $Id$
@@ -43,7 +42,7 @@ public class JavaWrapper {
     private static java.lang.ClassLoader getClassLoader() {
         String s = System.getProperty("bcel.classloader");
         if ((s == null) || "".equals(s)) {
-            s = "org.apache.commons.bcel6.util.ClassLoader";
+            throw new IllegalArgumentException("The property 'bcel.classloader' must be defined");
         }
         try {
             return (java.lang.ClassLoader) Class.forName(s).newInstance();


### PR DESCRIPTION
BCEL-110 Problem with JAXB if the bcel classloader is used; remove the broken ClassLoader class  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1696114 13f79535-47bb-0310-9956-ffa450edef68
