### PR TITLE
Remove redundant specification of type arguments (Java 7)

### DIFF
--- a/src/main/java/org/apache/commons/bcel6/classfile/AnnotationEntry.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/AnnotationEntry.java
@@ -56,7 +56,7 @@ public class AnnotationEntry implements Node, Serializable {
 
         final AnnotationEntry annotationEntry = new AnnotationEntry(input.readUnsignedShort(), constant_pool, isRuntimeVisible);
         final int num_element_value_pairs = (input.readUnsignedShort());
-        annotationEntry.element_value_pairs = new ArrayList<ElementValuePair>();
+        annotationEntry.element_value_pairs = new ArrayList<>();
         for (int i = 0; i < num_element_value_pairs; i++) {
             annotationEntry.element_value_pairs.add(new ElementValuePair(input.readUnsignedShort(), ElementValue.readElementValue(input, constant_pool),
                     constant_pool));
@@ -153,7 +153,7 @@ public class AnnotationEntry implements Node, Serializable {
 
     public static AnnotationEntry[] createAnnotationEntries(Attribute[] attrs) {
         // Find attributes that contain annotation data
-        List<AnnotationEntry> accumulatedAnnotations = new ArrayList<AnnotationEntry>(attrs.length);
+        List<AnnotationEntry> accumulatedAnnotations = new ArrayList<>(attrs.length);
         for (Attribute attribute : attrs) {
             if (attribute instanceof Annotations) {
                 Annotations runtimeAnnotations = (Annotations) attribute;

--- a/src/main/java/org/apache/commons/bcel6/classfile/Attribute.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Attribute.java
@@ -92,7 +92,7 @@ public abstract class Attribute implements Cloneable, Node, Serializable
         file.writeInt(length);
     }
 
-    private static final Map<String, Object> readers = new HashMap<String, Object>();
+    private static final Map<String, Object> readers = new HashMap<>();
 
     /**
      * Add an Attribute reader capable of parsing (user-defined) attributes

--- a/src/main/java/org/apache/commons/bcel6/classfile/DescendingVisitor.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/DescendingVisitor.java
@@ -32,7 +32,7 @@ public class DescendingVisitor implements Visitor
 
     private final Visitor visitor;
 
-    private final Stack<Object> stack = new Stack<Object>();
+    private final Stack<Object> stack = new Stack<>();
 
     /**
      * @return container of current entitity, i.e., predecessor during traversal

--- a/src/main/java/org/apache/commons/bcel6/classfile/JavaClass.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/JavaClass.java
@@ -718,7 +718,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      */
     public JavaClass[] getSuperClasses() throws ClassNotFoundException {
         JavaClass clazz = this;
-        List<JavaClass> allSuperClasses = new ArrayList<JavaClass>();
+        List<JavaClass> allSuperClasses = new ArrayList<>();
         for (clazz = clazz.getSuperClass(); clazz != null; clazz = clazz.getSuperClass()) {
             allSuperClasses.add(clazz);
         }
@@ -744,7 +744,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      */
     public JavaClass[] getAllInterfaces() throws ClassNotFoundException {
         ClassQueue queue = new ClassQueue();
-        Set<JavaClass> allInterfaces = new TreeSet<JavaClass>();
+        Set<JavaClass> allInterfaces = new TreeSet<>();
         queue.enqueue(this);
         while (!queue.empty()) {
             JavaClass clazz = queue.dequeue();

--- a/src/main/java/org/apache/commons/bcel6/classfile/ParameterAnnotationEntry.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ParameterAnnotationEntry.java
@@ -79,7 +79,7 @@ public class ParameterAnnotationEntry implements Node {
 
   public static ParameterAnnotationEntry[] createParameterAnnotationEntries(Attribute[] attrs) {
       // Find attributes that contain parameter annotation data
-      List<ParameterAnnotationEntry> accumulatedAnnotations = new ArrayList<ParameterAnnotationEntry>(attrs.length);
+      List<ParameterAnnotationEntry> accumulatedAnnotations = new ArrayList<>(attrs.length);
       for (Attribute attribute : attrs) {
           if (attribute instanceof ParameterAnnotations) {
               ParameterAnnotations runtimeAnnotations = (ParameterAnnotations)attribute;

--- a/src/main/java/org/apache/commons/bcel6/classfile/Unknown.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Unknown.java
@@ -43,7 +43,7 @@ public final class Unknown extends Attribute {
     private static final long serialVersionUID = -4099655108069755015L;
     private byte[] bytes; // TODO could be final if copy() were adjusted
     private final String name;
-    private static final Map<String, Unknown> unknown_attributes = new HashMap<String, Unknown>();
+    private static final Map<String, Unknown> unknown_attributes = new HashMap<>();
 
 
     /** @return array of unknown attributes, but just one for each kind.

--- a/src/main/java/org/apache/commons/bcel6/classfile/Utility.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Utility.java
@@ -574,7 +574,7 @@ public abstract class Utility {
      */
     public static String[] methodSignatureArgumentTypes( String signature, boolean chopit ) 
             throws ClassFormatException {
-        List<String> vec = new ArrayList<String>();
+        List<String> vec = new ArrayList<>();
         int index;
         try { // Read all declarations between for `(' and `)'
             if (signature.charAt(0) != '(') {

--- a/src/main/java/org/apache/commons/bcel6/generic/AnnotationEntryGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/AnnotationEntryGen.java
@@ -69,7 +69,7 @@ public class AnnotationEntryGen {
 
     private List<ElementValuePairGen> copyValues(ElementValuePair[] in, ConstantPoolGen cpool,
                                                  boolean copyPoolEntries) {
-        List<ElementValuePairGen> out = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> out = new ArrayList<>();
         for (ElementValuePair nvp : in) {
             out.add(new ElementValuePairGen(nvp, cpool, copyPoolEntries));
         }
@@ -125,7 +125,7 @@ public class AnnotationEntryGen {
 
     public void addElementNameValuePair(ElementValuePairGen evp) {
         if (evs == null) {
-            evs = new ArrayList<ElementValuePairGen>();
+            evs = new ArrayList<>();
         }
         evs.add(evp);
     }
@@ -247,7 +247,7 @@ public class AnnotationEntryGen {
                 riaIndex = cp.addUtf8("RuntimeInvisibleAnnotations");
             }
 
-            List<Attribute> newAttributes = new ArrayList<Attribute>();
+            List<Attribute> newAttributes = new ArrayList<>();
             if (rvaData.length > 2) {
                 newAttributes.add(
                         new RuntimeVisibleAnnotations(rvaIndex, rvaData.length, new DataInputStream(new ByteArrayInputStream(rvaData)), cp.getConstantPool()));
@@ -332,7 +332,7 @@ public class AnnotationEntryGen {
             if (totalInvisCount > 0) {
                 riaIndex = cp.addUtf8("RuntimeInvisibleParameterAnnotations");
             }
-            List<Attribute> newAttributes = new ArrayList<Attribute>();
+            List<Attribute> newAttributes = new ArrayList<>();
             if (totalVisCount > 0) {
                 newAttributes
                         .add(new RuntimeVisibleParameterAnnotations(rvaIndex,

--- a/src/main/java/org/apache/commons/bcel6/generic/ArrayElementValueGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ArrayElementValueGen.java
@@ -37,7 +37,7 @@ public class ArrayElementValueGen extends ElementValueGen
     public ArrayElementValueGen(ConstantPoolGen cp)
     {
         super(ARRAY, cp);
-        evalues = new ArrayList<ElementValueGen>();
+        evalues = new ArrayList<>();
     }
 
     public ArrayElementValueGen(int type, ElementValue[] datums,
@@ -48,7 +48,7 @@ public class ArrayElementValueGen extends ElementValueGen
             throw new RuntimeException(
                     "Only element values of type array can be built with this ctor - type specified: " + type);
         }
-        this.evalues = new ArrayList<ElementValueGen>();
+        this.evalues = new ArrayList<>();
         for (ElementValue datum : datums) {
             evalues.add(ElementValueGen.copy(datum, cpool, true));
         }
@@ -77,7 +77,7 @@ public class ArrayElementValueGen extends ElementValueGen
             boolean copyPoolEntries)
     {
         super(ARRAY, cpool);
-        evalues = new ArrayList<ElementValueGen>();
+        evalues = new ArrayList<>();
         ElementValue[] in = value.getElementValuesArray();
         for (ElementValue element : in) {
             evalues.add(ElementValueGen.copy(element, cpool, copyPoolEntries));

--- a/src/main/java/org/apache/commons/bcel6/generic/ClassGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ClassGen.java
@@ -52,11 +52,11 @@ public class ClassGen extends AccessFlags implements Cloneable {
     private int major = Constants.MAJOR_1_1, minor = Constants.MINOR_1_1;
     private ConstantPoolGen cp; // Template for building up constant pool
     // ArrayLists instead of arrays to gather fields, methods, etc.
-    private final List<Field> field_vec = new ArrayList<Field>();
-    private final List<Method> method_vec = new ArrayList<Method>();
-    private final List<Attribute> attribute_vec = new ArrayList<Attribute>();
-    private final List<String> interface_vec = new ArrayList<String>();
-    private final List<AnnotationEntryGen> annotation_vec = new ArrayList<AnnotationEntryGen>();
+    private final List<Field> field_vec = new ArrayList<>();
+    private final List<Method> method_vec = new ArrayList<>();
+    private final List<Attribute> attribute_vec = new ArrayList<>();
+    private final List<String> interface_vec = new ArrayList<>();
+    private final List<AnnotationEntryGen> annotation_vec = new ArrayList<>();
 
     private static BCELComparator _cmp = new BCELComparator() {
 
@@ -166,7 +166,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      */
     private AnnotationEntryGen[] unpackAnnotations(Attribute[] attrs)
     {
-        List<AnnotationEntryGen> annotationGenObjs = new ArrayList<AnnotationEntryGen>();
+        List<AnnotationEntryGen> annotationGenObjs = new ArrayList<>();
         for (Attribute attr : attrs) {
             if (attr instanceof RuntimeVisibleAnnotations)
             {
@@ -525,7 +525,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
      */
     public void addObserver( ClassObserver o ) {
         if (observers == null) {
-            observers = new ArrayList<ClassObserver>();
+            observers = new ArrayList<>();
         }
         observers.add(o);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/ConstantPoolGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ConstantPoolGen.java
@@ -198,7 +198,7 @@ public class ConstantPoolGen implements java.io.Serializable {
         }
     }
 
-    private final Map<String, Index> string_table = new HashMap<String, Index>();
+    private final Map<String, Index> string_table = new HashMap<>();
 
 
     /** 
@@ -235,7 +235,7 @@ public class ConstantPoolGen implements java.io.Serializable {
         return ret;
     }
 
-    private final Map<String, Index> class_table = new HashMap<String, Index>();
+    private final Map<String, Index> class_table = new HashMap<>();
 
 
     /**
@@ -374,7 +374,7 @@ public class ConstantPoolGen implements java.io.Serializable {
         return ret;
     }
 
-    private final Map<String, Index> utf8_table = new HashMap<String, Index>();
+    private final Map<String, Index> utf8_table = new HashMap<>();
 
 
     /** 
@@ -486,7 +486,7 @@ public class ConstantPoolGen implements java.io.Serializable {
         return ret;
     }
 
-    private final Map<String, Index> n_a_t_table = new HashMap<String, Index>();
+    private final Map<String, Index> n_a_t_table = new HashMap<>();
 
 
     /** 
@@ -528,7 +528,7 @@ public class ConstantPoolGen implements java.io.Serializable {
         return ret;
     }
 
-    private final Map<String, Index> cp_table = new HashMap<String, Index>();
+    private final Map<String, Index> cp_table = new HashMap<>();
 
 
     /** 

--- a/src/main/java/org/apache/commons/bcel6/generic/FieldGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FieldGen.java
@@ -269,7 +269,7 @@ public class FieldGen extends FieldGenOrMethodGen {
      */
     public void addObserver( FieldObserver o ) {
         if (observers == null) {
-            observers = new ArrayList<FieldObserver>();
+            observers = new ArrayList<>();
         }
         observers.add(o);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/FieldGenOrMethodGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FieldGenOrMethodGen.java
@@ -36,8 +36,8 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
     protected String name;
     protected Type type;
     protected ConstantPoolGen cp;
-    private final List<Attribute> attribute_vec = new ArrayList<Attribute>();
-    protected List<AnnotationEntryGen>       annotation_vec= new ArrayList<AnnotationEntryGen>();
+    private final List<Attribute> attribute_vec = new ArrayList<>();
+    protected List<AnnotationEntryGen>       annotation_vec= new ArrayList<>();
 
 
     protected FieldGenOrMethodGen() {

--- a/src/main/java/org/apache/commons/bcel6/generic/InstructionHandle.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/InstructionHandle.java
@@ -197,7 +197,7 @@ public class InstructionHandle implements java.io.Serializable {
      */
     public void addTargeter( InstructionTargeter t ) {
         if (targeters == null) {
-            targeters = new HashSet<InstructionTargeter>();
+            targeters = new HashSet<>();
         }
         //if(!targeters.contains(t))
         targeters.add(t);
@@ -244,7 +244,7 @@ public class InstructionHandle implements java.io.Serializable {
      */
     public void addAttribute( Object key, Object attr ) {
         if (attributes == null) {
-            attributes = new HashMap<Object, Object>(3);
+            attributes = new HashMap<>(3);
         }
         attributes.put(key, attr);
     }
@@ -277,7 +277,7 @@ public class InstructionHandle implements java.io.Serializable {
      */
     public Collection<Object> getAttributes() {
         if (attributes == null) {
-            attributes = new HashMap<Object, Object>(3);
+            attributes = new HashMap<>(3);
         }
         return attributes.values();
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/InstructionList.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/InstructionList.java
@@ -707,7 +707,7 @@ public class InstructionList implements Serializable {
         }
         first.prev = null; // Completely separated from rest of list
         last.next = null;
-        List<InstructionHandle> target_vec = new ArrayList<InstructionHandle>();
+        List<InstructionHandle> target_vec = new ArrayList<>();
         for (InstructionHandle ih = first; ih != null; ih = ih.next) {
             ih.getInstruction().dispose(); // e.g. BranchInstructions release their targets
         }
@@ -963,7 +963,7 @@ public class InstructionList implements Serializable {
      */
     public Instruction[] getInstructions() {
         ByteSequence bytes = new ByteSequence(getByteCode());
-        List<Instruction> instructions = new ArrayList<Instruction>();
+        List<Instruction> instructions = new ArrayList<>();
         try {
             while (bytes.available() > 0) {
                 instructions.add(Instruction.readInstruction(bytes));
@@ -1058,7 +1058,7 @@ public class InstructionList implements Serializable {
      * @return complete, i.e., deep copy of this list
      */
     public InstructionList copy() {
-        Map<InstructionHandle, InstructionHandle> map = new HashMap<InstructionHandle, InstructionHandle>();
+        Map<InstructionHandle, InstructionHandle> map = new HashMap<>();
         InstructionList il = new InstructionList();
         /* Pass 1: Make copies of all instructions, append them to the new list
          * and associate old instruction references with the new ones, i.e.,
@@ -1253,7 +1253,7 @@ public class InstructionList implements Serializable {
      */
     public void addObserver( InstructionListObserver o ) {
         if (observers == null) {
-            observers = new ArrayList<InstructionListObserver>();
+            observers = new ArrayList<>();
         }
         observers.add(o);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/MethodGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/MethodGen.java
@@ -67,11 +67,11 @@ public class MethodGen extends FieldGenOrMethodGen {
     private int max_stack;
     private InstructionList il;
     private boolean strip_attributes;
-    private final List<LocalVariableGen> variable_vec = new ArrayList<LocalVariableGen>();
-    private final List<LineNumberGen> line_number_vec = new ArrayList<LineNumberGen>();
-    private final List<CodeExceptionGen> exception_vec = new ArrayList<CodeExceptionGen>();
-    private final List<String> throws_vec = new ArrayList<String>();
-    private final List<Attribute> code_attrs_vec = new ArrayList<Attribute>();
+    private final List<LocalVariableGen> variable_vec = new ArrayList<>();
+    private final List<LineNumberGen> line_number_vec = new ArrayList<>();
+    private final List<CodeExceptionGen> exception_vec = new ArrayList<>();
+    private final List<String> throws_vec = new ArrayList<>();
+    private final List<Attribute> code_attrs_vec = new ArrayList<>();
 
     private List<AnnotationEntryGen>[] param_annotations; // Array of lists containing AnnotationGen objects
     private boolean hasParameterAnnotations = false;
@@ -899,8 +899,8 @@ public class MethodGen extends FieldGenOrMethodGen {
 
     static final class BranchStack {
 
-        Stack<BranchTarget> branchTargets = new Stack<BranchTarget>();
-        Hashtable<InstructionHandle, BranchTarget> visitedTargets = new Hashtable<InstructionHandle, BranchTarget>();
+        Stack<BranchTarget> branchTargets = new Stack<>();
+        Hashtable<InstructionHandle, BranchTarget> visitedTargets = new Hashtable<>();
 
 
         public void push( InstructionHandle target, int stackDepth ) {
@@ -1015,7 +1015,7 @@ public class MethodGen extends FieldGenOrMethodGen {
      */
     public void addObserver( MethodObserver o ) {
         if (observers == null) {
-            observers = new ArrayList<MethodObserver>();
+            observers = new ArrayList<>();
         }
         observers.add(o);
     }
@@ -1124,7 +1124,7 @@ public class MethodGen extends FieldGenOrMethodGen {
                     final List<AnnotationEntryGen>[] parmList = new List[arg_types.length];
                     param_annotations = parmList;
                     for (int j = 0; j < arg_types.length; j++) {
-                        param_annotations[j] = new ArrayList<AnnotationEntryGen>();
+                        param_annotations[j] = new ArrayList<>();
                     }
                 }
                 hasParameterAnnotations = true;
@@ -1157,7 +1157,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
     private List<AnnotationEntryGen> makeMutableVersion(AnnotationEntry[] mutableArray)
     {
-        List<AnnotationEntryGen> result = new ArrayList<AnnotationEntryGen>();
+        List<AnnotationEntryGen> result = new ArrayList<>();
         for (AnnotationEntry element : mutableArray) {
             result.add(new AnnotationEntryGen(element, getConstantPool(),
                     false));
@@ -1183,7 +1183,7 @@ public class MethodGen extends FieldGenOrMethodGen {
         }
         else
         {
-            List<AnnotationEntryGen> l = new ArrayList<AnnotationEntryGen>();
+            List<AnnotationEntryGen> l = new ArrayList<>();
             l.add(annotation);
             param_annotations[parameterIndex] = l;
         }

--- a/src/main/java/org/apache/commons/bcel6/util/BCELFactory.java
+++ b/src/main/java/org/apache/commons/bcel6/util/BCELFactory.java
@@ -76,7 +76,7 @@ class BCELFactory extends EmptyVisitor {
         _out = out;
     }
 
-    private final Map<Instruction, InstructionHandle> branch_map = new HashMap<Instruction, InstructionHandle>();
+    private final Map<Instruction, InstructionHandle> branch_map = new HashMap<>();
 
 
     public void start() {
@@ -259,7 +259,7 @@ class BCELFactory extends EmptyVisitor {
     }
 
     // Memorize BranchInstructions that need an update
-    private final List<BranchInstruction> branches = new ArrayList<BranchInstruction>();
+    private final List<BranchInstruction> branches = new ArrayList<>();
 
 
     @Override

--- a/src/main/java/org/apache/commons/bcel6/util/ClassLoaderRepository.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassLoaderRepository.java
@@ -40,7 +40,7 @@ public class ClassLoaderRepository implements Repository {
 
     private static final long serialVersionUID = -1052781833503868187L;
     private final java.lang.ClassLoader loader;
-    private final Map<String, JavaClass> loadedClasses = new HashMap<String, JavaClass>(); // CLASSNAME X JAVACLASS
+    private final Map<String, JavaClass> loadedClasses = new HashMap<>(); // CLASSNAME X JAVACLASS
 
 
     public ClassLoaderRepository(java.lang.ClassLoader loader) {

--- a/src/main/java/org/apache/commons/bcel6/util/ClassPath.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassPath.java
@@ -71,7 +71,7 @@ public class ClassPath implements Serializable {
      */
     public ClassPath(String class_path) {
         this.class_path = class_path;
-        List<PathEntry> vec = new ArrayList<PathEntry>();
+        List<PathEntry> vec = new ArrayList<>();
         for (StringTokenizer tok = new StringTokenizer(class_path, File.pathSeparator); tok.hasMoreTokens();) {
             String path = tok.nextToken();
             if (!path.equals("")) {
@@ -147,10 +147,10 @@ public class ClassPath implements Serializable {
         String class_path = System.getProperty("java.class.path");
         String boot_path = System.getProperty("sun.boot.class.path");
         String ext_path = System.getProperty("java.ext.dirs");
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         getPathComponents(class_path, list);
         getPathComponents(boot_path, list);
-        List<String> dirs = new ArrayList<String>();
+        List<String> dirs = new ArrayList<>();
         getPathComponents(ext_path, dirs);
         for (String d : dirs) {
             File ext_dir = new File(d);

--- a/src/main/java/org/apache/commons/bcel6/util/ClassQueue.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassQueue.java
@@ -30,7 +30,7 @@ import org.apache.commons.bcel6.classfile.JavaClass;
 public class ClassQueue implements java.io.Serializable {
 
     private static final long serialVersionUID = 685144104322420292L;
-    protected LinkedList<JavaClass> vec = new LinkedList<JavaClass>();
+    protected LinkedList<JavaClass> vec = new LinkedList<>();
 
 
     public void enqueue( JavaClass clazz ) {

--- a/src/main/java/org/apache/commons/bcel6/util/ClassSet.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassSet.java
@@ -34,7 +34,7 @@ import org.apache.commons.bcel6.classfile.JavaClass;
 public class ClassSet implements java.io.Serializable {
 
     private static final long serialVersionUID = -7476907380350035254L;
-    private final Map<String, JavaClass> _map = new HashMap<String, JavaClass>();
+    private final Map<String, JavaClass> _map = new HashMap<>();
 
 
     public boolean add( JavaClass clazz ) {

--- a/src/main/java/org/apache/commons/bcel6/util/ClassStack.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassStack.java
@@ -30,7 +30,7 @@ import org.apache.commons.bcel6.classfile.JavaClass;
 public class ClassStack implements java.io.Serializable {
 
     private static final long serialVersionUID = 6126079269396985982L;
-    private final Stack<JavaClass> stack = new Stack<JavaClass>();
+    private final Stack<JavaClass> stack = new Stack<>();
 
 
     public void push( JavaClass clazz ) {

--- a/src/main/java/org/apache/commons/bcel6/util/InstructionFinder.java
+++ b/src/main/java/org/apache/commons/bcel6/util/InstructionFinder.java
@@ -72,7 +72,7 @@ public class InstructionFinder {
     // LATIN-1
     private static final int NO_OPCODES = 256; // Potential number,
     // some are not used
-    private static final Map<String, String> map = new HashMap<String, String>();
+    private static final Map<String, String> map = new HashMap<>();
     private final InstructionList il;
     private String il_string; // instruction list
     // as string
@@ -223,7 +223,7 @@ public class InstructionFinder {
                     + " not found in instruction list.");
         }
         Pattern regex = Pattern.compile(search);
-        List<InstructionHandle[]> matches = new ArrayList<InstructionHandle[]>();
+        List<InstructionHandle[]> matches = new ArrayList<>();
         Matcher matcher = regex.matcher(il_string);
         while (start < il_string.length() && matcher.find(start)) {
             int startExpr = matcher.start();

--- a/src/main/java/org/apache/commons/bcel6/util/SyntheticRepository.java
+++ b/src/main/java/org/apache/commons/bcel6/util/SyntheticRepository.java
@@ -44,9 +44,9 @@ public class SyntheticRepository implements Repository {
 
     private static final long serialVersionUID = 2923440730410019444L;
     //private static final String DEFAULT_PATH = ClassPath.getClassPath();
-    private static final Map<ClassPath, SyntheticRepository> _instances = new HashMap<ClassPath, SyntheticRepository>(); // CLASSPATH X REPOSITORY
+    private static final Map<ClassPath, SyntheticRepository> _instances = new HashMap<>(); // CLASSPATH X REPOSITORY
     private ClassPath _path = null;
-    private final Map<String, SoftReference<JavaClass>> _loadedClasses = new HashMap<String, SoftReference<JavaClass>>(); // CLASSNAME X JAVACLASS
+    private final Map<String, SoftReference<JavaClass>> _loadedClasses = new HashMap<>(); // CLASSNAME X JAVACLASS
 
 
     private SyntheticRepository(ClassPath path) {
@@ -74,7 +74,7 @@ public class SyntheticRepository implements Repository {
      */
     @Override
     public void storeClass( JavaClass clazz ) {
-        _loadedClasses.put(clazz.getClassName(), new SoftReference<JavaClass>(clazz));
+        _loadedClasses.put(clazz.getClassName(), new SoftReference<>(clazz));
         clazz.setRepository(this);
     }
 

--- a/src/main/java/org/apache/commons/bcel6/verifier/PassVerifier.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/PassVerifier.java
@@ -48,7 +48,7 @@ import java.util.List;
 public abstract class PassVerifier {
 
     /** The (warning) messages. */
-    private final List<String> messages = new ArrayList<String>();
+    private final List<String> messages = new ArrayList<>();
     /** The VerificationResult cache. */
     private VerificationResult verificationResult = null;
 

--- a/src/main/java/org/apache/commons/bcel6/verifier/Verifier.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/Verifier.java
@@ -54,9 +54,9 @@ public class Verifier {
     /** A Pass2Verifier for this Verifier instance. */
     private Pass2Verifier p2v;
     /** The Pass3aVerifiers for this Verifier instance. Key: Interned string specifying the method number. */
-    private final Map<String, Pass3aVerifier> p3avs = new HashMap<String, Pass3aVerifier>();
+    private final Map<String, Pass3aVerifier> p3avs = new HashMap<>();
     /** The Pass3bVerifiers for this Verifier instance. Key: Interned string specifying the method number. */
-    private final Map<String, Pass3bVerifier> p3bvs = new HashMap<String, Pass3bVerifier>();
+    private final Map<String, Pass3bVerifier> p3bvs = new HashMap<>();
 
 
     /** Returns the VerificationResult for the given pass. */
@@ -145,7 +145,7 @@ public class Verifier {
      * A prefix shows from which verifying pass a message originates.
      */
     public String[] getMessages() throws ClassNotFoundException {
-        List<String> messages = new ArrayList<String>();
+        List<String> messages = new ArrayList<>();
         if (p1v != null) {
             String[] p1m = p1v.getMessages();
             for (String element : p1m) {

--- a/src/main/java/org/apache/commons/bcel6/verifier/VerifierFactory.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/VerifierFactory.java
@@ -36,7 +36,7 @@ public class VerifierFactory {
     /**
      * The HashMap that holds the data about the already-constructed Verifier instances.
      */
-    private static final Map<String, Verifier> hashMap = new HashMap<String, Verifier>();
+    private static final Map<String, Verifier> hashMap = new HashMap<>();
     /**
      * The VerifierFactoryObserver instances that observe the VerifierFactory.
      */

--- a/src/main/java/org/apache/commons/bcel6/verifier/VerifierFactoryListModel.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/VerifierFactoryListModel.java
@@ -34,8 +34,8 @@ import javax.swing.event.ListDataListener;
 public class VerifierFactoryListModel implements org.apache.commons.bcel6.verifier.VerifierFactoryObserver,
         javax.swing.ListModel<String> {
 
-    private final List<ListDataListener> listeners = new ArrayList<ListDataListener>();
-    private final Set<String> cache = new TreeSet<String>();
+    private final List<ListDataListener> listeners = new ArrayList<>();
+    private final Set<String> cache = new TreeSet<>();
 
 
     public VerifierFactoryListModel() {

--- a/src/main/java/org/apache/commons/bcel6/verifier/statics/IntList.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/statics/IntList.java
@@ -31,7 +31,7 @@ public class IntList{
     private final List<Integer> theList;
     /** This constructor creates an empty list. */
     IntList(){
-        theList = new ArrayList<Integer>();
+        theList = new ArrayList<>();
     }
     /** Adds an element to the list. */
     void add(int i){

--- a/src/main/java/org/apache/commons/bcel6/verifier/statics/LocalVariableInfo.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/statics/LocalVariableInfo.java
@@ -34,9 +34,9 @@ import org.apache.commons.bcel6.verifier.exc.LocalVariableInfoInconsistentExcept
 public class LocalVariableInfo{
 
     /** The types database. KEY: String representing the offset integer. */
-    private final Hashtable<String, Type> types = new Hashtable<String, Type>();
+    private final Hashtable<String, Type> types = new Hashtable<>();
     /** The names database. KEY: String representing the offset integer. */
-    private final Hashtable<String, String> names = new Hashtable<String, String>();
+    private final Hashtable<String, String> names = new Hashtable<>();
 
     /**
      * Adds a name of a local variable and a certain slot to our 'names'

--- a/src/main/java/org/apache/commons/bcel6/verifier/statics/Pass2Verifier.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/statics/Pass2Verifier.java
@@ -191,7 +191,7 @@ public final class Pass2Verifier extends PassVerifier {
      */
     private void every_class_has_an_accessible_superclass(){
         try {
-        Set<String> hs = new HashSet<String>(); // save class names to detect circular inheritance
+        Set<String> hs = new HashSet<>(); // save class names to detect circular inheritance
         JavaClass jc = Repository.lookupClass(myOwner.getClassName());
         int supidx = -1;
 
@@ -241,7 +241,7 @@ public final class Pass2Verifier extends PassVerifier {
      */
     private void final_methods_are_not_overridden(){
         try {
-        Map<String, String> hashmap = new HashMap<String, String>();
+        Map<String, String> hashmap = new HashMap<>();
         JavaClass jc = Repository.lookupClass(myOwner.getClassName());
 
         int supidx = -1;
@@ -327,9 +327,9 @@ public final class Pass2Verifier extends PassVerifier {
         private final int cplen; // == cp.getLength() -- to save computing power.
         private final DescendingVisitor carrier;
 
-        private final Set<String> field_names = new HashSet<String>();
-        private final Set<String> field_names_and_desc = new HashSet<String>();
-        private final Set<String> method_names_and_desc = new HashSet<String>();
+        private final Set<String> field_names = new HashSet<>();
+        private final Set<String> field_names_and_desc = new HashSet<>();
+        private final Set<String> method_names_and_desc = new HashSet<>();
 
         private CPESSC_Visitor(JavaClass _jc){
             jc = _jc;

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/ControlFlowGraph.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/ControlFlowGraph.java
@@ -89,8 +89,8 @@ public class ControlFlowGraph{
             }
 
             instruction = inst;
-            inFrames = new HashMap<InstructionContext, Frame>();
-            outFrames = new HashMap<InstructionContext, Frame>();
+            inFrames = new HashMap<>();
+            outFrames = new HashMap<>();
         }
 
         /* Satisfies InstructionContext.getTag(). */
@@ -404,7 +404,7 @@ public class ControlFlowGraph{
     private final ExceptionHandlers exceptionhandlers;
 
     /** All InstructionContext instances of this ControlFlowGraph. */
-    private final Map<InstructionHandle, InstructionContext> instructionContexts = new HashMap<InstructionHandle, InstructionContext>(); //keys: InstructionHandle, values: InstructionContextImpl
+    private final Map<InstructionHandle, InstructionContext> instructionContexts = new HashMap<>(); //keys: InstructionHandle, values: InstructionContextImpl
 
     /** 
      * A Control Flow Graph.

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/ExceptionHandlers.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/ExceptionHandlers.java
@@ -43,7 +43,7 @@ public class ExceptionHandlers{
      * Constructor. Creates a new ExceptionHandlers instance.
      */
     public ExceptionHandlers(MethodGen mg){
-        exceptionhandlers = new HashMap<InstructionHandle, Set<ExceptionHandler>>();
+        exceptionhandlers = new HashMap<>();
         CodeExceptionGen[] cegs = mg.getExceptionHandlers();
         for (CodeExceptionGen ceg : cegs) {
             ExceptionHandler eh = new ExceptionHandler(ceg.getCatchType(), ceg.getHandlerPC());
@@ -51,7 +51,7 @@ public class ExceptionHandlers{
                 Set<ExceptionHandler> hs;
                 hs = exceptionhandlers.get(ih);
                 if (hs == null){
-                    hs = new HashSet<ExceptionHandler>();
+                    hs = new HashSet<>();
                     exceptionhandlers.put(ih, hs);
                 }
                 hs.add(eh);

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/OperandStack.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/OperandStack.java
@@ -36,7 +36,7 @@ import org.apache.commons.bcel6.verifier.exc.StructuralCodeConstraintException;
 public class OperandStack{
 
     /** We hold the stack information here. */
-    private ArrayList<Type> stack = new ArrayList<Type>();
+    private ArrayList<Type> stack = new ArrayList<>();
 
     /** The maximum number of stack slots this OperandStack instance may hold. */
     private final int maxStack;

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/Pass3bVerifier.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/Pass3bVerifier.java
@@ -76,8 +76,8 @@ public final class Pass3bVerifier extends PassVerifier{
      * we have about its symbolic execution predecessors.
      */
     private static final class InstructionContextQueue{
-        private final List<InstructionContext> ics = new Vector<InstructionContext>();
-        private final List<ArrayList<InstructionContext>> ecs = new Vector<ArrayList<InstructionContext>>();
+        private final List<InstructionContext> ics = new Vector<>();
+        private final List<ArrayList<InstructionContext>> ecs = new Vector<>();
         public void add(InstructionContext ic, ArrayList<InstructionContext> executionChain){
             ics.add(ic);
             ecs.add(executionChain);

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/Subroutines.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/Subroutines.java
@@ -85,7 +85,7 @@ public class Subroutines{
         private int localVariable = UNSET;
 
         /** The instructions that belong to this subroutine. */
-        private final Set<InstructionHandle> instructions = new HashSet<InstructionHandle>(); // Elements: InstructionHandle
+        private final Set<InstructionHandle> instructions = new HashSet<>(); // Elements: InstructionHandle
 
         /*
          * Refer to the Subroutine interface for documentation.
@@ -99,7 +99,7 @@ public class Subroutines{
          * The JSR or JSR_W instructions that define this
          * subroutine by targeting it.
          */
-        private final Set<InstructionHandle> theJSRs = new HashSet<InstructionHandle>();
+        private final Set<InstructionHandle> theJSRs = new HashSet<>();
 
         /**
          * The RET instruction that leaves this subroutine.
@@ -226,7 +226,7 @@ public class Subroutines{
         /* Satisfies Subroutine.getRecursivelyAccessedLocalsIndices(). */
         @Override
         public int[] getRecursivelyAccessedLocalsIndices(){
-            Set<Integer> s = new HashSet<Integer>();
+            Set<Integer> s = new HashSet<>();
             int[] lvs = getAccessedLocalsIndices();
             for (int lv : lvs) {
                 s.add(Integer.valueOf(lv));
@@ -263,7 +263,7 @@ public class Subroutines{
         @Override
         public int[] getAccessedLocalsIndices(){
             //TODO: Implement caching.
-            Set<Integer> acc = new HashSet<Integer>();
+            Set<Integer> acc = new HashSet<>();
             if (theRET == null && this != TOPLEVEL){
                 throw new AssertionViolatedException("This subroutine object must be built up completely before calculating accessed locals.");
             }
@@ -307,7 +307,7 @@ public class Subroutines{
          */
         @Override
         public Subroutine[] subSubs(){
-            Set<Subroutine> h = new HashSet<Subroutine>();
+            Set<Subroutine> h = new HashSet<>();
 
             for (InstructionHandle ih : instructions) {
                 Instruction inst = ih.getInstruction();
@@ -351,7 +351,7 @@ public class Subroutines{
      * Key: InstructionHandle of the leader of the subroutine.
      * Elements: SubroutineImpl objects.
      */
-    private final Map<InstructionHandle, Subroutine> subroutines = new HashMap<InstructionHandle, Subroutine>();
+    private final Map<InstructionHandle, Subroutine> subroutines = new HashMap<>();
 
     /**
      * This is referring to a special subroutine, namely the
@@ -375,7 +375,7 @@ public class Subroutines{
         TOPLEVEL = new SubroutineImpl();
 
         // Calculate "real" subroutines.
-        Set<InstructionHandle> sub_leaders = new HashSet<InstructionHandle>(); // Elements: InstructionHandle
+        Set<InstructionHandle> sub_leaders = new HashSet<>(); // Elements: InstructionHandle
         for (InstructionHandle element : all) {
             Instruction inst = element.getInstruction();
             if (inst instanceof JsrInstruction){
@@ -409,11 +409,11 @@ public class Subroutines{
 
         // Now do a BFS from every subroutine leader to find all the
         // instructions that belong to a subroutine.
-        Set<InstructionHandle> instructions_assigned = new HashSet<InstructionHandle>(); // we don't want to assign an instruction to two or more Subroutine objects.
+        Set<InstructionHandle> instructions_assigned = new HashSet<>(); // we don't want to assign an instruction to two or more Subroutine objects.
 
-        Map<InstructionHandle, Integer> colors = new HashMap<InstructionHandle, Integer>(); //Graph colouring. Key: InstructionHandle, Value: Integer .
+        Map<InstructionHandle, Integer> colors = new HashMap<>(); //Graph colouring. Key: InstructionHandle, Value: Integer .
 
-        List<InstructionHandle> Q = new ArrayList<InstructionHandle>();        
+        List<InstructionHandle> Q = new ArrayList<>();        
         for (InstructionHandle actual : sub_leaders) {
             // Do some BFS with "actual" as the root of the graph.
             // Init colors

--- a/src/test/java/org/apache/commons/bcel6/AbstractTestCase.java
+++ b/src/test/java/org/apache/commons/bcel6/AbstractTestCase.java
@@ -91,7 +91,7 @@ public abstract class AbstractTestCase extends TestCase
     protected Attribute[] findAttribute(String name, JavaClass clazz)
     {
         Attribute[] all = clazz.getAttributes();
-        List<Attribute> chosenAttrsList = new ArrayList<Attribute>();
+        List<Attribute> chosenAttrsList = new ArrayList<>();
         for (Attribute element : all) {
             if (verbose) {
                 System.err.println("Attribute: " + element.getName());
@@ -105,7 +105,7 @@ public abstract class AbstractTestCase extends TestCase
 
     protected Attribute findAttribute(String name, Attribute[] all)
     {
-        List<Attribute> chosenAttrsList = new ArrayList<Attribute>();
+        List<Attribute> chosenAttrsList = new ArrayList<>();
         for (Attribute element : all) {
             if (verbose) {
                 System.err.println("Attribute: " + element.getName());
@@ -174,7 +174,7 @@ public abstract class AbstractTestCase extends TestCase
                 ElementValueGen.STRING, cp, aFruit);
         ElementValuePairGen nvGen = new ElementValuePairGen("fruit", evg, cp);
         ObjectType t = new ObjectType("SimpleStringAnnotation");
-        List<ElementValuePairGen> elements = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
         return new AnnotationEntryGen(t, elements, visibility, cp);
     }

--- a/src/test/java/org/apache/commons/bcel6/BCELBenchmark.java
+++ b/src/test/java/org/apache/commons/bcel6/BCELBenchmark.java
@@ -58,7 +58,7 @@ public class BCELBenchmark {
     }
 
     private Iterable<JarEntry> getClasses(JarFile jar) {
-        return new IteratorIterable<JarEntry>(new FilterIterator<JarEntry>(new EnumerationIterator<JarEntry>(jar.entries()), new Predicate<JarEntry>() {
+        return new IteratorIterable<>(new FilterIterator<>(new EnumerationIterator<>(jar.entries()), new Predicate<JarEntry>() {
             @Override
             public boolean evaluate(JarEntry entry) {
                 return entry.getName().endsWith(".class");

--- a/src/test/java/org/apache/commons/bcel6/generic/AnnotationGenTestCase.java
+++ b/src/test/java/org/apache/commons/bcel6/generic/AnnotationGenTestCase.java
@@ -66,7 +66,7 @@ public class AnnotationGenTestCase extends AbstractTestCase
                 "Should include string 'id=4' but says: " + nvGen.toString(),
                 nvGen.toString().contains("id=4"));
         ObjectType t = new ObjectType("SimpleAnnotation");
-        List<ElementValuePairGen> elements = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
         // Build an annotation of type 'SimpleAnnotation' with 'id=4' as the
         // only value :)
@@ -91,12 +91,12 @@ public class AnnotationGenTestCase extends AbstractTestCase
                 "Should include string 'id=4' but says: " + nvGen.toString(),
                 nvGen.toString().contains("id=4"));
         ObjectType t = new ObjectType("SimpleAnnotation");
-        List<ElementValuePairGen> elements = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
         // Build a RV annotation of type 'SimpleAnnotation' with 'id=4' as the
         // only value :)
         AnnotationEntryGen a = new AnnotationEntryGen(t, elements, true, cp);
-        List<AnnotationEntryGen> v = new ArrayList<AnnotationEntryGen>();
+        List<AnnotationEntryGen> v = new ArrayList<>();
         v.add(a);
         Attribute[] attributes = AnnotationEntryGen.getAnnotationAttributes(cp, v);
         boolean foundRV = false;
@@ -111,7 +111,7 @@ public class AnnotationGenTestCase extends AbstractTestCase
         // Build a RIV annotation of type 'SimpleAnnotation' with 'id=4' as the
         // only value :)
         AnnotationEntryGen a2 = new AnnotationEntryGen(t, elements, false, cp);
-        List<AnnotationEntryGen> v2 = new ArrayList<AnnotationEntryGen>();
+        List<AnnotationEntryGen> v2 = new ArrayList<>();
         v2.add(a2);
         Attribute[] attributes2 = AnnotationEntryGen.getAnnotationAttributes(cp, v2);
         boolean foundRIV = false;

--- a/src/test/java/org/apache/commons/bcel6/generic/GeneratingAnnotatedClassesTestCase.java
+++ b/src/test/java/org/apache/commons/bcel6/generic/GeneratingAnnotatedClassesTestCase.java
@@ -655,7 +655,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
                 ElementValueGen.PRIMITIVE_INT, cp, 4);
         ElementValuePairGen nvGen = new ElementValuePairGen("id", evg, cp);
         ObjectType t = new ObjectType("SimpleAnnotation");
-        List<ElementValuePairGen> elements = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
         AnnotationEntryGen a = new AnnotationEntryGen(t, elements, true, cp);
         return a;
@@ -668,7 +668,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
                 ElementValueGen.STRING, cp, aFruit);
         ElementValuePairGen nvGen = new ElementValuePairGen("fruit", evg, cp);
         ObjectType t = new ObjectType("SimpleStringAnnotation");
-        List<ElementValuePairGen> elements = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
         return new AnnotationEntryGen(t, elements, true, cp);
     }
@@ -680,7 +680,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
         ArrayElementValueGen array = new ArrayElementValueGen(cp);
         array.addElement(new AnnotationElementValueGen(a, cp));
         ElementValuePairGen nvp = new ElementValuePairGen("value", array, cp);
-        List<ElementValuePairGen> elements = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvp);
         return new AnnotationEntryGen(new ObjectType("CombinedAnnotation"),
                 elements, true, cp);
@@ -692,7 +692,7 @@ public class GeneratingAnnotatedClassesTestCase extends AbstractTestCase
                 ElementValueGen.PRIMITIVE_INT, cp, 4);
         ElementValuePairGen nvGen = new ElementValuePairGen("id", evg, cp);
         ObjectType t = new ObjectType("SimpleAnnotation");
-        List<ElementValuePairGen> elements = new ArrayList<ElementValuePairGen>();
+        List<ElementValuePairGen> elements = new ArrayList<>();
         elements.add(nvGen);
         AnnotationEntryGen a = new AnnotationEntryGen(t, elements, false, cp);
         return a;


### PR DESCRIPTION
Remove redundant specification of type arguments (Java 7).  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1695790 13f79535-47bb-0310-9956-ffa450edef68
