### PR TITLE
Add missing '@Override' annotations to implementations of interface 

### DIFF
--- a/src/main/java/org/apache/commons/bcel6/classfile/AnnotationEntry.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/AnnotationEntry.java
@@ -88,6 +88,7 @@ public class AnnotationEntry implements Node, Serializable {
      * 
      * @param v Visitor object
      */
+    @Override
     public void accept(Visitor v) {
         v.visitAnnotationEntry(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/Attribute.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Attribute.java
@@ -76,6 +76,7 @@ public abstract class Attribute implements Cloneable, Node, Serializable
      * @param v
      *            Visitor object
      */
+    @Override
     public abstract void accept(Visitor v);
 
     /**

--- a/src/main/java/org/apache/commons/bcel6/classfile/CodeException.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/CodeException.java
@@ -90,6 +90,7 @@ public final class CodeException implements Cloneable, Node, Serializable {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitCodeException(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/Constant.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Constant.java
@@ -37,6 +37,7 @@ public abstract class Constant implements Cloneable, Node, Serializable {
     private static final long serialVersionUID = 5739037344085356353L;
     private static BCELComparator _cmp = new BCELComparator() {
 
+        @Override
         public boolean equals( Object o1, Object o2 ) {
             Constant THIS = (Constant) o1;
             Constant THAT = (Constant) o2;
@@ -44,6 +45,7 @@ public abstract class Constant implements Cloneable, Node, Serializable {
         }
 
 
+        @Override
         public int hashCode( Object o ) {
             Constant THIS = (Constant) o;
             return THIS.toString().hashCode();
@@ -72,6 +74,7 @@ public abstract class Constant implements Cloneable, Node, Serializable {
      *
      * @param v Visitor object
      */
+    @Override
     public abstract void accept( Visitor v );
 
 

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantClass.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantClass.java
@@ -102,6 +102,7 @@ public final class ConstantClass extends Constant implements ConstantObject {
 
     /** @return String object
      */
+    @Override
     public Object getConstantValue( ConstantPool cp ) {
         Constant c = cp.getConstant(name_index, Constants.CONSTANT_Utf8);
         return ((ConstantUtf8) c).getBytes();

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantDouble.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantDouble.java
@@ -110,6 +110,7 @@ public final class ConstantDouble extends Constant implements ConstantObject {
 
     /** @return Double object
      */
+    @Override
     public Object getConstantValue( ConstantPool cp ) {
         return new Double(bytes);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantFloat.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantFloat.java
@@ -111,6 +111,7 @@ public final class ConstantFloat extends Constant implements ConstantObject {
 
     /** @return Float object
      */
+    @Override
     public Object getConstantValue( ConstantPool cp ) {
         return new Float(bytes);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantInteger.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantInteger.java
@@ -110,6 +110,7 @@ public final class ConstantInteger extends Constant implements ConstantObject {
 
     /** @return Integer object
      */
+    @Override
     public Object getConstantValue( ConstantPool cp ) {
         return Integer.valueOf(bytes);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantLong.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantLong.java
@@ -110,6 +110,7 @@ public final class ConstantLong extends Constant implements ConstantObject {
 
     /** @return Long object
      */
+    @Override
     public Object getConstantValue( ConstantPool cp ) {
         return Long.valueOf(bytes);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantPool.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantPool.java
@@ -88,6 +88,7 @@ public class ConstantPool implements Cloneable, Node, Serializable {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitConstantPool(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/ConstantString.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ConstantString.java
@@ -110,6 +110,7 @@ public final class ConstantString extends Constant implements ConstantObject {
 
     /** @return String object
      */
+    @Override
     public Object getConstantValue( ConstantPool cp ) {
         Constant c = cp.getConstant(string_index, Constants.CONSTANT_Utf8);
         return ((ConstantUtf8) c).getBytes();

--- a/src/main/java/org/apache/commons/bcel6/classfile/DescendingVisitor.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/DescendingVisitor.java
@@ -85,6 +85,7 @@ public class DescendingVisitor implements Visitor
         clazz.accept(this);
     }
 
+    @Override
     public void visitJavaClass(JavaClass _clazz)
     {
         stack.push(_clazz);
@@ -105,6 +106,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitAnnotation(Annotations annotation)
     {
         stack.push(annotation);
@@ -116,6 +118,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitAnnotationEntry(AnnotationEntry annotationEntry)
     {
         stack.push(annotationEntry);
@@ -123,6 +126,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitField(Field field)
     {
         stack.push(field);
@@ -134,6 +138,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantValue(ConstantValue cv)
     {
         stack.push(cv);
@@ -141,6 +146,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitMethod(Method method)
     {
         stack.push(method);
@@ -152,6 +158,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitExceptionTable(ExceptionTable table)
     {
         stack.push(table);
@@ -159,6 +166,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitCode(Code code)
     {
         stack.push(code);
@@ -174,6 +182,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitCodeException(CodeException ce)
     {
         stack.push(ce);
@@ -181,6 +190,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitLineNumberTable(LineNumberTable table)
     {
         stack.push(table);
@@ -192,6 +202,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitLineNumber(LineNumber number)
     {
         stack.push(number);
@@ -199,6 +210,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitLocalVariableTable(LocalVariableTable table)
     {
         stack.push(table);
@@ -210,6 +222,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitStackMap(StackMap table)
     {
         stack.push(table);
@@ -221,6 +234,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitStackMapEntry(StackMapEntry var)
     {
         stack.push(var);
@@ -228,6 +242,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitStackMapTable(StackMapTable table)
     {
         stack.push(table);
@@ -239,6 +254,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitStackMapTableEntry(StackMapTableEntry var)
     {
         stack.push(var);
@@ -246,6 +262,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitLocalVariable(LocalVariable var)
     {
         stack.push(var);
@@ -253,6 +270,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantPool(ConstantPool cp)
     {
         stack.push(cp);
@@ -268,6 +286,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantClass(ConstantClass constant)
     {
         stack.push(constant);
@@ -275,6 +294,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantDouble(ConstantDouble constant)
     {
         stack.push(constant);
@@ -282,6 +302,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantFieldref(ConstantFieldref constant)
     {
         stack.push(constant);
@@ -289,6 +310,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantFloat(ConstantFloat constant)
     {
         stack.push(constant);
@@ -296,6 +318,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantInteger(ConstantInteger constant)
     {
         stack.push(constant);
@@ -303,6 +326,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantInterfaceMethodref(
             ConstantInterfaceMethodref constant)
     {
@@ -311,6 +335,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantInvokeDynamic(
             ConstantInvokeDynamic constant)
     {
@@ -319,6 +344,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantLong(ConstantLong constant)
     {
         stack.push(constant);
@@ -326,6 +352,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantMethodref(ConstantMethodref constant)
     {
         stack.push(constant);
@@ -333,6 +360,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantNameAndType(ConstantNameAndType constant)
     {
         stack.push(constant);
@@ -340,6 +368,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantString(ConstantString constant)
     {
         stack.push(constant);
@@ -347,6 +376,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitConstantUtf8(ConstantUtf8 constant)
     {
         stack.push(constant);
@@ -354,6 +384,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitInnerClasses(InnerClasses ic)
     {
         stack.push(ic);
@@ -365,6 +396,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitInnerClass(InnerClass inner)
     {
         stack.push(inner);
@@ -372,6 +404,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitBootstrapMethods(BootstrapMethods bm)
     {
         stack.push(bm);
@@ -384,6 +417,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitDeprecated(Deprecated attribute)
     {
         stack.push(attribute);
@@ -391,6 +425,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitSignature(Signature attribute)
     {
         stack.push(attribute);
@@ -398,6 +433,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitSourceFile(SourceFile attribute)
     {
         stack.push(attribute);
@@ -405,6 +441,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitSynthetic(Synthetic attribute)
     {
         stack.push(attribute);
@@ -412,6 +449,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitUnknown(Unknown attribute)
     {
         stack.push(attribute);
@@ -419,6 +457,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitAnnotationDefault(AnnotationDefault obj)
     {
         stack.push(obj);
@@ -426,6 +465,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitEnclosingMethod(EnclosingMethod obj)
     {
         stack.push(obj);
@@ -433,6 +473,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitLocalVariableTypeTable(LocalVariableTypeTable obj)
     {
         stack.push(obj);
@@ -440,6 +481,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitParameterAnnotation(ParameterAnnotations obj)
     {
         stack.push(obj);
@@ -447,6 +489,7 @@ public class DescendingVisitor implements Visitor
         stack.pop();
     }
 
+    @Override
     public void visitMethodParameters(MethodParameters obj)
     {
         stack.push(obj);

--- a/src/main/java/org/apache/commons/bcel6/classfile/EmptyVisitor.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/EmptyVisitor.java
@@ -33,6 +33,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitAnnotation(Annotations obj)
     {
     }
@@ -40,6 +41,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitParameterAnnotation(ParameterAnnotations obj)
     {
     }
@@ -47,6 +49,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitAnnotationEntry(AnnotationEntry obj)
     {
     }
@@ -54,90 +57,112 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitAnnotationDefault(AnnotationDefault obj)
     {
     }
 
+    @Override
     public void visitCode(Code obj)
     {
     }
 
+    @Override
     public void visitCodeException(CodeException obj)
     {
     }
 
+    @Override
     public void visitConstantClass(ConstantClass obj)
     {
     }
 
+    @Override
     public void visitConstantDouble(ConstantDouble obj)
     {
     }
 
+    @Override
     public void visitConstantFieldref(ConstantFieldref obj)
     {
     }
 
+    @Override
     public void visitConstantFloat(ConstantFloat obj)
     {
     }
 
+    @Override
     public void visitConstantInteger(ConstantInteger obj)
     {
     }
 
+    @Override
     public void visitConstantInterfaceMethodref(ConstantInterfaceMethodref obj)
     {
     }
 
+    @Override
     public void visitConstantInvokeDynamic(ConstantInvokeDynamic obj)
     {
     }
 
+    @Override
     public void visitConstantLong(ConstantLong obj)
     {
     }
 
+    @Override
     public void visitConstantMethodref(ConstantMethodref obj)
     {
     }
 
+    @Override
     public void visitConstantNameAndType(ConstantNameAndType obj)
     {
     }
 
+    @Override
     public void visitConstantPool(ConstantPool obj)
     {
     }
 
+    @Override
     public void visitConstantString(ConstantString obj)
     {
     }
 
+    @Override
     public void visitConstantUtf8(ConstantUtf8 obj)
     {
     }
 
+    @Override
     public void visitConstantValue(ConstantValue obj)
     {
     }
 
+    @Override
     public void visitDeprecated(Deprecated obj)
     {
     }
 
+    @Override
     public void visitExceptionTable(ExceptionTable obj)
     {
     }
 
+    @Override
     public void visitField(Field obj)
     {
     }
 
+    @Override
     public void visitInnerClass(InnerClass obj)
     {
     }
 
+    @Override
     public void visitInnerClasses(InnerClasses obj)
     {
     }
@@ -145,54 +170,67 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitBootstrapMethods(BootstrapMethods obj)
     {
     }
 
+    @Override
     public void visitJavaClass(JavaClass obj)
     {
     }
 
+    @Override
     public void visitLineNumber(LineNumber obj)
     {
     }
 
+    @Override
     public void visitLineNumberTable(LineNumberTable obj)
     {
     }
 
+    @Override
     public void visitLocalVariable(LocalVariable obj)
     {
     }
 
+    @Override
     public void visitLocalVariableTable(LocalVariableTable obj)
     {
     }
 
+    @Override
     public void visitMethod(Method obj)
     {
     }
 
+    @Override
     public void visitSignature(Signature obj)
     {
     }
 
+    @Override
     public void visitSourceFile(SourceFile obj)
     {
     }
 
+    @Override
     public void visitSynthetic(Synthetic obj)
     {
     }
 
+    @Override
     public void visitUnknown(Unknown obj)
     {
     }
 
+    @Override
     public void visitStackMap(StackMap obj)
     {
     }
 
+    @Override
     public void visitStackMapEntry(StackMapEntry obj)
     {
     }
@@ -200,6 +238,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitStackMapTable(StackMapTable obj)
     {
     }
@@ -207,6 +246,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitStackMapTableEntry(StackMapTableEntry obj)
     {
     }
@@ -214,6 +254,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitEnclosingMethod(EnclosingMethod obj)
     {
     }
@@ -221,6 +262,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitLocalVariableTypeTable(LocalVariableTypeTable obj)
     {
     }
@@ -228,6 +270,7 @@ public class EmptyVisitor implements Visitor
     /**
      * @since 6.0
      */
+    @Override
     public void visitMethodParameters(MethodParameters obj)
     {
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/Field.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Field.java
@@ -35,6 +35,7 @@ public final class Field extends FieldOrMethod {
     private static final long serialVersionUID = -4604082205545049134L;
     private static final BCELComparator _cmp = new BCELComparator() {
 
+        @Override
         public boolean equals( Object o1, Object o2 ) {
             Field THIS = (Field) o1;
             Field THAT = (Field) o2;
@@ -43,6 +44,7 @@ public final class Field extends FieldOrMethod {
         }
 
 
+        @Override
         public int hashCode( Object o ) {
             Field THIS = (Field) o;
             return THIS.getSignature().hashCode() ^ THIS.getName().hashCode();
@@ -89,6 +91,7 @@ public final class Field extends FieldOrMethod {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitField(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/InnerClass.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/InnerClass.java
@@ -83,6 +83,7 @@ public final class InnerClass implements Cloneable, Node, Serializable {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitInnerClass(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/JavaClass.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/JavaClass.java
@@ -76,6 +76,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
     
     private static final BCELComparator _cmp = new BCELComparator() { // TODO could be final (setter unused)
 
+        @Override
         public boolean equals( Object o1, Object o2 ) {
             JavaClass THIS = (JavaClass) o1;
             JavaClass THAT = (JavaClass) o2;
@@ -83,6 +84,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
         }
 
 
+        @Override
         public int hashCode( Object o ) {
             JavaClass THIS = (JavaClass) o;
             return THIS.getClassName().hashCode();
@@ -207,6 +209,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitJavaClass(this);
     }
@@ -787,6 +790,7 @@ public class JavaClass extends AccessFlags implements Cloneable, Node, Comparabl
      * Return the natural ordering of two JavaClasses.
      * This ordering is based on the class name
      */
+    @Override
     public int compareTo( JavaClass obj ) {
         return getClassName().compareTo(obj.getClassName());
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/LineNumber.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/LineNumber.java
@@ -78,6 +78,7 @@ public final class LineNumber implements Cloneable, Node, Serializable {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitLineNumber(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/LocalVariable.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/LocalVariable.java
@@ -91,6 +91,7 @@ public final class LocalVariable implements Cloneable, Node, Serializable {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitLocalVariable(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/Method.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/Method.java
@@ -36,6 +36,7 @@ public final class Method extends FieldOrMethod {
     private static final long serialVersionUID = -2013983967283787941L;
     private static BCELComparator _cmp = new BCELComparator() {
 
+        @Override
         public boolean equals( Object o1, Object o2 ) {
             Method THIS = (Method) o1;
             Method THAT = (Method) o2;
@@ -44,6 +45,7 @@ public final class Method extends FieldOrMethod {
         }
 
 
+        @Override
         public int hashCode( Object o ) {
             Method THIS = (Method) o;
             return THIS.getSignature().hashCode() ^ THIS.getName().hashCode();
@@ -102,6 +104,7 @@ public final class Method extends FieldOrMethod {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         v.visitMethod(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/classfile/ParameterAnnotationEntry.java
+++ b/src/main/java/org/apache/commons/bcel6/classfile/ParameterAnnotationEntry.java
@@ -58,6 +58,7 @@ public class ParameterAnnotationEntry implements Node {
      *
      * @param v Visitor object
      */
+    @Override
     public void accept( Visitor v ) {
         // v.visitParameterAnnotationEntry(this);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/ACONST_NULL.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ACONST_NULL.java
@@ -38,6 +38,7 @@ public class ACONST_NULL extends Instruction implements PushInstruction, TypedIn
 
     /** @return Type.NULL
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.NULL;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/ANEWARRAY.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ANEWARRAY.java
@@ -44,6 +44,7 @@ public class ANEWARRAY extends CPInstruction implements LoadClass, AllocationIns
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_CLASS_AND_INTERFACE_RESOLUTION,
             ExceptionConstants.NEGATIVE_ARRAY_SIZE_EXCEPTION);
@@ -70,6 +71,7 @@ public class ANEWARRAY extends CPInstruction implements LoadClass, AllocationIns
     }
 
 
+    @Override
     public ObjectType getLoadClassType( ConstantPoolGen cpg ) {
         Type t = getType(cpg);
         if (t instanceof ArrayType) {

--- a/src/main/java/org/apache/commons/bcel6/generic/ARRAYLENGTH.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ARRAYLENGTH.java
@@ -37,6 +37,7 @@ public class ARRAYLENGTH extends Instruction implements ExceptionThrower, StackP
 
     /** @return exceptions this instruction may cause
      */
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.NULL_POINTER_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/ATHROW.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ATHROW.java
@@ -38,6 +38,7 @@ public class ATHROW extends Instruction implements UnconditionalBranch, Exceptio
 
     /** @return exceptions this instruction may cause
      */
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.THROWABLE

--- a/src/main/java/org/apache/commons/bcel6/generic/ArithmeticInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ArithmeticInstruction.java
@@ -48,6 +48,7 @@ public abstract class ArithmeticInstruction extends Instruction implements Typed
 
     /** @return type associated with the instruction
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         switch (opcode) {
             case Constants.DADD:

--- a/src/main/java/org/apache/commons/bcel6/generic/ArrayInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ArrayInstruction.java
@@ -46,6 +46,7 @@ public abstract class ArrayInstruction extends Instruction implements ExceptionT
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_ARRAY_EXCEPTION);
     }
@@ -53,6 +54,7 @@ public abstract class ArrayInstruction extends Instruction implements ExceptionT
 
     /** @return type associated with the instruction
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         switch (opcode) {
             case org.apache.commons.bcel6.Constants.IALOAD:

--- a/src/main/java/org/apache/commons/bcel6/generic/BIPUSH.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/BIPUSH.java
@@ -80,6 +80,7 @@ public class BIPUSH extends Instruction implements ConstantPushInstruction {
     }
 
 
+    @Override
     public Number getValue() {
         return Integer.valueOf(b);
     }
@@ -87,6 +88,7 @@ public class BIPUSH extends Instruction implements ConstantPushInstruction {
 
     /** @return Type.BYTE
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.BYTE;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/BranchInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/BranchInstruction.java
@@ -212,6 +212,7 @@ public abstract class BranchInstruction extends Instruction implements Instructi
      * @param old_ih old target
      * @param new_ih new target
      */
+    @Override
     public void updateTarget( InstructionHandle old_ih, InstructionHandle new_ih ) {
         if (target == old_ih) {
             setTarget(new_ih);
@@ -224,6 +225,7 @@ public abstract class BranchInstruction extends Instruction implements Instructi
     /**
      * @return true, if ih is target of this instruction
      */
+    @Override
     public boolean containsTarget( InstructionHandle ih ) {
         return (target == ih);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/CHECKCAST.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/CHECKCAST.java
@@ -49,12 +49,14 @@ public class CHECKCAST extends CPInstruction implements LoadClass, ExceptionThro
 
     /** @return exceptions this instruction may cause
      */
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_CLASS_AND_INTERFACE_RESOLUTION,
             ExceptionConstants.CLASS_CAST_EXCEPTION);
     }
 
 
+    @Override
     public ObjectType getLoadClassType( ConstantPoolGen cpg ) {
         Type t = getType(cpg);
         if (t instanceof ArrayType) {

--- a/src/main/java/org/apache/commons/bcel6/generic/CPInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/CPInstruction.java
@@ -115,6 +115,7 @@ public abstract class CPInstruction extends Instruction implements TypedInstruct
     /**
      * @return index in constant pool referred by this instruction.
      */
+    @Override
     public final int getIndex() {
         return index;
     }
@@ -124,6 +125,7 @@ public abstract class CPInstruction extends Instruction implements TypedInstruct
      * Set the index to constant pool.
      * @param index in  constant pool.
      */
+    @Override
     public void setIndex( int index ) { // TODO could be package-protected?
         if (index < 0) {
             throw new ClassGenException("Negative index value: " + index);
@@ -134,6 +136,7 @@ public abstract class CPInstruction extends Instruction implements TypedInstruct
 
     /** @return type related with this instruction.
      */
+    @Override
     public Type getType( ConstantPoolGen cpg ) {
         ConstantPool cp = cpg.getConstantPool();
         String name = cp.getConstantString(index, org.apache.commons.bcel6.Constants.CONSTANT_Class);

--- a/src/main/java/org/apache/commons/bcel6/generic/ClassGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ClassGen.java
@@ -60,6 +60,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
 
     private static BCELComparator _cmp = new BCELComparator() {
 
+        @Override
         public boolean equals( Object o1, Object o2 ) {
             ClassGen THIS = (ClassGen) o1;
             ClassGen THAT = (ClassGen) o2;
@@ -67,6 +68,7 @@ public class ClassGen extends AccessFlags implements Cloneable {
         }
 
 
+        @Override
         public int hashCode( Object o ) {
             ClassGen THIS = (ClassGen) o;
             return THIS.getClassName().hashCode();

--- a/src/main/java/org/apache/commons/bcel6/generic/CodeExceptionGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/CodeExceptionGen.java
@@ -107,6 +107,7 @@ public final class CodeExceptionGen implements InstructionTargeter, Cloneable, j
      * @param old_ih old target, either start or end
      * @param new_ih new target
      */
+    @Override
     public void updateTarget( InstructionHandle old_ih, InstructionHandle new_ih ) {
         boolean targeted = false;
         if (start_pc == old_ih) {
@@ -131,6 +132,7 @@ public final class CodeExceptionGen implements InstructionTargeter, Cloneable, j
     /**
      * @return true, if ih is target of this handler
      */
+    @Override
     public boolean containsTarget( InstructionHandle ih ) {
         return (start_pc == ih) || (end_pc == ih) || (handler_pc == ih);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/ConversionInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ConversionInstruction.java
@@ -48,6 +48,7 @@ public abstract class ConversionInstruction extends Instruction implements Typed
 
     /** @return type associated with the instruction
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         switch (opcode) {
             case Constants.D2I:

--- a/src/main/java/org/apache/commons/bcel6/generic/DCMPG.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/DCMPG.java
@@ -33,6 +33,7 @@ public class DCMPG extends Instruction implements TypedInstruction, StackProduce
 
     /** @return Type.DOUBLE
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.DOUBLE;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/DCMPL.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/DCMPL.java
@@ -33,6 +33,7 @@ public class DCMPL extends Instruction implements TypedInstruction, StackProduce
 
     /** @return Type.DOUBLE
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.DOUBLE;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/DCONST.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/DCONST.java
@@ -51,6 +51,7 @@ public class DCONST extends Instruction implements ConstantPushInstruction {
     }
 
 
+    @Override
     public Number getValue() {
         return new Double(value);
     }
@@ -58,6 +59,7 @@ public class DCONST extends Instruction implements ConstantPushInstruction {
 
     /** @return Type.DOUBLE
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.DOUBLE;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/EmptyVisitor.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/EmptyVisitor.java
@@ -24,728 +24,909 @@ package org.apache.commons.bcel6.generic;
  */
 public abstract class EmptyVisitor implements Visitor {
 
+    @Override
     public void visitStackInstruction( StackInstruction obj ) {
     }
 
 
+    @Override
     public void visitLocalVariableInstruction( LocalVariableInstruction obj ) {
     }
 
 
+    @Override
     public void visitBranchInstruction( BranchInstruction obj ) {
     }
 
 
+    @Override
     public void visitLoadClass( LoadClass obj ) {
     }
 
 
+    @Override
     public void visitFieldInstruction( FieldInstruction obj ) {
     }
 
 
+    @Override
     public void visitIfInstruction( IfInstruction obj ) {
     }
 
 
+    @Override
     public void visitConversionInstruction( ConversionInstruction obj ) {
     }
 
 
+    @Override
     public void visitPopInstruction( PopInstruction obj ) {
     }
 
 
+    @Override
     public void visitJsrInstruction( JsrInstruction obj ) {
     }
 
 
+    @Override
     public void visitGotoInstruction( GotoInstruction obj ) {
     }
 
 
+    @Override
     public void visitStoreInstruction( StoreInstruction obj ) {
     }
 
 
+    @Override
     public void visitTypedInstruction( TypedInstruction obj ) {
     }
 
 
+    @Override
     public void visitSelect( Select obj ) {
     }
 
 
+    @Override
     public void visitUnconditionalBranch( UnconditionalBranch obj ) {
     }
 
 
+    @Override
     public void visitPushInstruction( PushInstruction obj ) {
     }
 
 
+    @Override
     public void visitArithmeticInstruction( ArithmeticInstruction obj ) {
     }
 
 
+    @Override
     public void visitCPInstruction( CPInstruction obj ) {
     }
 
 
+    @Override
     public void visitInvokeInstruction( InvokeInstruction obj ) {
     }
 
 
+    @Override
     public void visitArrayInstruction( ArrayInstruction obj ) {
     }
 
 
+    @Override
     public void visitAllocationInstruction( AllocationInstruction obj ) {
     }
 
 
+    @Override
     public void visitReturnInstruction( ReturnInstruction obj ) {
     }
 
 
+    @Override
     public void visitFieldOrMethod( FieldOrMethod obj ) {
     }
 
 
+    @Override
     public void visitConstantPushInstruction( ConstantPushInstruction obj ) {
     }
 
 
+    @Override
     public void visitExceptionThrower( ExceptionThrower obj ) {
     }
 
 
+    @Override
     public void visitLoadInstruction( LoadInstruction obj ) {
     }
 
 
+    @Override
     public void visitVariableLengthInstruction( VariableLengthInstruction obj ) {
     }
 
 
+    @Override
     public void visitStackProducer( StackProducer obj ) {
     }
 
 
+    @Override
     public void visitStackConsumer( StackConsumer obj ) {
     }
 
 
+    @Override
     public void visitACONST_NULL( ACONST_NULL obj ) {
     }
 
 
+    @Override
     public void visitGETSTATIC( GETSTATIC obj ) {
     }
 
 
+    @Override
     public void visitIF_ICMPLT( IF_ICMPLT obj ) {
     }
 
 
+    @Override
     public void visitMONITOREXIT( MONITOREXIT obj ) {
     }
 
 
+    @Override
     public void visitIFLT( IFLT obj ) {
     }
 
 
+    @Override
     public void visitLSTORE( LSTORE obj ) {
     }
 
 
+    @Override
     public void visitPOP2( POP2 obj ) {
     }
 
 
+    @Override
     public void visitBASTORE( BASTORE obj ) {
     }
 
 
+    @Override
     public void visitISTORE( ISTORE obj ) {
     }
 
 
+    @Override
     public void visitCHECKCAST( CHECKCAST obj ) {
     }
 
 
+    @Override
     public void visitFCMPG( FCMPG obj ) {
     }
 
 
+    @Override
     public void visitI2F( I2F obj ) {
     }
 
 
+    @Override
     public void visitATHROW( ATHROW obj ) {
     }
 
 
+    @Override
     public void visitDCMPL( DCMPL obj ) {
     }
 
 
+    @Override
     public void visitARRAYLENGTH( ARRAYLENGTH obj ) {
     }
 
 
+    @Override
     public void visitDUP( DUP obj ) {
     }
 
 
+    @Override
     public void visitINVOKESTATIC( INVOKESTATIC obj ) {
     }
 
 
+    @Override
     public void visitLCONST( LCONST obj ) {
     }
 
 
+    @Override
     public void visitDREM( DREM obj ) {
     }
 
 
+    @Override
     public void visitIFGE( IFGE obj ) {
     }
 
 
+    @Override
     public void visitCALOAD( CALOAD obj ) {
     }
 
 
+    @Override
     public void visitLASTORE( LASTORE obj ) {
     }
 
 
+    @Override
     public void visitI2D( I2D obj ) {
     }
 
 
+    @Override
     public void visitDADD( DADD obj ) {
     }
 
 
+    @Override
     public void visitINVOKESPECIAL( INVOKESPECIAL obj ) {
     }
 
 
+    @Override
     public void visitIAND( IAND obj ) {
     }
 
 
+    @Override
     public void visitPUTFIELD( PUTFIELD obj ) {
     }
 
 
+    @Override
     public void visitILOAD( ILOAD obj ) {
     }
 
 
+    @Override
     public void visitDLOAD( DLOAD obj ) {
     }
 
 
+    @Override
     public void visitDCONST( DCONST obj ) {
     }
 
 
+    @Override
     public void visitNEW( NEW obj ) {
     }
 
 
+    @Override
     public void visitIFNULL( IFNULL obj ) {
     }
 
 
+    @Override
     public void visitLSUB( LSUB obj ) {
     }
 
 
+    @Override
     public void visitL2I( L2I obj ) {
     }
 
 
+    @Override
     public void visitISHR( ISHR obj ) {
     }
 
 
+    @Override
     public void visitTABLESWITCH( TABLESWITCH obj ) {
     }
 
 
+    @Override
     public void visitIINC( IINC obj ) {
     }
 
 
+    @Override
     public void visitDRETURN( DRETURN obj ) {
     }
 
 
+    @Override
     public void visitFSTORE( FSTORE obj ) {
     }
 
 
+    @Override
     public void visitDASTORE( DASTORE obj ) {
     }
 
 
+    @Override
     public void visitIALOAD( IALOAD obj ) {
     }
 
 
+    @Override
     public void visitDDIV( DDIV obj ) {
     }
 
 
+    @Override
     public void visitIF_ICMPGE( IF_ICMPGE obj ) {
     }
 
 
+    @Override
     public void visitLAND( LAND obj ) {
     }
 
 
+    @Override
     public void visitIDIV( IDIV obj ) {
     }
 
 
+    @Override
     public void visitLOR( LOR obj ) {
     }
 
 
+    @Override
     public void visitCASTORE( CASTORE obj ) {
     }
 
 
+    @Override
     public void visitFREM( FREM obj ) {
     }
 
 
+    @Override
     public void visitLDC( LDC obj ) {
     }
 
 
+    @Override
     public void visitBIPUSH( BIPUSH obj ) {
     }
 
 
+    @Override
     public void visitDSTORE( DSTORE obj ) {
     }
 
 
+    @Override
     public void visitF2L( F2L obj ) {
     }
 
 
+    @Override
     public void visitFMUL( FMUL obj ) {
     }
 
 
+    @Override
     public void visitLLOAD( LLOAD obj ) {
     }
 
 
+    @Override
     public void visitJSR( JSR obj ) {
     }
 
 
+    @Override
     public void visitFSUB( FSUB obj ) {
     }
 
 
+    @Override
     public void visitSASTORE( SASTORE obj ) {
     }
 
 
+    @Override
     public void visitALOAD( ALOAD obj ) {
     }
 
 
+    @Override
     public void visitDUP2_X2( DUP2_X2 obj ) {
     }
 
 
+    @Override
     public void visitRETURN( RETURN obj ) {
     }
 
 
+    @Override
     public void visitDALOAD( DALOAD obj ) {
     }
 
 
+    @Override
     public void visitSIPUSH( SIPUSH obj ) {
     }
 
 
+    @Override
     public void visitDSUB( DSUB obj ) {
     }
 
 
+    @Override
     public void visitL2F( L2F obj ) {
     }
 
 
+    @Override
     public void visitIF_ICMPGT( IF_ICMPGT obj ) {
     }
 
 
+    @Override
     public void visitF2D( F2D obj ) {
     }
 
 
+    @Override
     public void visitI2L( I2L obj ) {
     }
 
 
+    @Override
     public void visitIF_ACMPNE( IF_ACMPNE obj ) {
     }
 
 
+    @Override
     public void visitPOP( POP obj ) {
     }
 
 
+    @Override
     public void visitI2S( I2S obj ) {
     }
 
 
+    @Override
     public void visitIFEQ( IFEQ obj ) {
     }
 
 
+    @Override
     public void visitSWAP( SWAP obj ) {
     }
 
 
+    @Override
     public void visitIOR( IOR obj ) {
     }
 
 
+    @Override
     public void visitIREM( IREM obj ) {
     }
 
 
+    @Override
     public void visitIASTORE( IASTORE obj ) {
     }
 
 
+    @Override
     public void visitNEWARRAY( NEWARRAY obj ) {
     }
 
 
+    @Override
     public void visitINVOKEINTERFACE( INVOKEINTERFACE obj ) {
     }
 
 
+    @Override
     public void visitINEG( INEG obj ) {
     }
 
 
+    @Override
     public void visitLCMP( LCMP obj ) {
     }
 
 
+    @Override
     public void visitJSR_W( JSR_W obj ) {
     }
 
 
+    @Override
     public void visitMULTIANEWARRAY( MULTIANEWARRAY obj ) {
     }
 
 
+    @Override
     public void visitDUP_X2( DUP_X2 obj ) {
     }
 
 
+    @Override
     public void visitSALOAD( SALOAD obj ) {
     }
 
 
+    @Override
     public void visitIFNONNULL( IFNONNULL obj ) {
     }
 
 
+    @Override
     public void visitDMUL( DMUL obj ) {
     }
 
 
+    @Override
     public void visitIFNE( IFNE obj ) {
     }
 
 
+    @Override
     public void visitIF_ICMPLE( IF_ICMPLE obj ) {
     }
 
 
+    @Override
     public void visitLDC2_W( LDC2_W obj ) {
     }
 
 
+    @Override
     public void visitGETFIELD( GETFIELD obj ) {
     }
 
 
+    @Override
     public void visitLADD( LADD obj ) {
     }
 
 
+    @Override
     public void visitNOP( NOP obj ) {
     }
 
 
+    @Override
     public void visitFALOAD( FALOAD obj ) {
     }
 
 
+    @Override
     public void visitINSTANCEOF( INSTANCEOF obj ) {
     }
 
 
+    @Override
     public void visitIFLE( IFLE obj ) {
     }
 
 
+    @Override
     public void visitLXOR( LXOR obj ) {
     }
 
 
+    @Override
     public void visitLRETURN( LRETURN obj ) {
     }
 
 
+    @Override
     public void visitFCONST( FCONST obj ) {
     }
 
 
+    @Override
     public void visitIUSHR( IUSHR obj ) {
     }
 
 
+    @Override
     public void visitBALOAD( BALOAD obj ) {
     }
 
 
+    @Override
     public void visitDUP2( DUP2 obj ) {
     }
 
 
+    @Override
     public void visitIF_ACMPEQ( IF_ACMPEQ obj ) {
     }
 
 
+    @Override
     public void visitIMPDEP1( IMPDEP1 obj ) {
     }
 
 
+    @Override
     public void visitMONITORENTER( MONITORENTER obj ) {
     }
 
 
+    @Override
     public void visitLSHL( LSHL obj ) {
     }
 
 
+    @Override
     public void visitDCMPG( DCMPG obj ) {
     }
 
 
+    @Override
     public void visitD2L( D2L obj ) {
     }
 
 
+    @Override
     public void visitIMPDEP2( IMPDEP2 obj ) {
     }
 
 
+    @Override
     public void visitL2D( L2D obj ) {
     }
 
 
+    @Override
     public void visitRET( RET obj ) {
     }
 
 
+    @Override
     public void visitIFGT( IFGT obj ) {
     }
 
 
+    @Override
     public void visitIXOR( IXOR obj ) {
     }
 
 
+    @Override
     public void visitINVOKEVIRTUAL( INVOKEVIRTUAL obj ) {
     }
 
 
+    @Override
     public void visitFASTORE( FASTORE obj ) {
     }
 
 
+    @Override
     public void visitIRETURN( IRETURN obj ) {
     }
 
 
+    @Override
     public void visitIF_ICMPNE( IF_ICMPNE obj ) {
     }
 
 
+    @Override
     public void visitFLOAD( FLOAD obj ) {
     }
 
 
+    @Override
     public void visitLDIV( LDIV obj ) {
     }
 
 
+    @Override
     public void visitPUTSTATIC( PUTSTATIC obj ) {
     }
 
 
+    @Override
     public void visitAALOAD( AALOAD obj ) {
     }
 
 
+    @Override
     public void visitD2I( D2I obj ) {
     }
 
 
+    @Override
     public void visitIF_ICMPEQ( IF_ICMPEQ obj ) {
     }
 
 
+    @Override
     public void visitAASTORE( AASTORE obj ) {
     }
 
 
+    @Override
     public void visitARETURN( ARETURN obj ) {
     }
 
 
+    @Override
     public void visitDUP2_X1( DUP2_X1 obj ) {
     }
 
 
+    @Override
     public void visitFNEG( FNEG obj ) {
     }
 
 
+    @Override
     public void visitGOTO_W( GOTO_W obj ) {
     }
 
 
+    @Override
     public void visitD2F( D2F obj ) {
     }
 
 
+    @Override
     public void visitGOTO( GOTO obj ) {
     }
 
 
+    @Override
     public void visitISUB( ISUB obj ) {
     }
 
 
+    @Override
     public void visitF2I( F2I obj ) {
     }
 
 
+    @Override
     public void visitDNEG( DNEG obj ) {
     }
 
 
+    @Override
     public void visitICONST( ICONST obj ) {
     }
 
 
+    @Override
     public void visitFDIV( FDIV obj ) {
     }
 
 
+    @Override
     public void visitI2B( I2B obj ) {
     }
 
 
+    @Override
     public void visitLNEG( LNEG obj ) {
     }
 
 
+    @Override
     public void visitLREM( LREM obj ) {
     }
 
 
+    @Override
     public void visitIMUL( IMUL obj ) {
     }
 
 
+    @Override
     public void visitIADD( IADD obj ) {
     }
 
 
+    @Override
     public void visitLSHR( LSHR obj ) {
     }
 
 
+    @Override
     public void visitLOOKUPSWITCH( LOOKUPSWITCH obj ) {
     }
 
 
+    @Override
     public void visitDUP_X1( DUP_X1 obj ) {
     }
 
 
+    @Override
     public void visitFCMPL( FCMPL obj ) {
     }
 
 
+    @Override
     public void visitI2C( I2C obj ) {
     }
 
 
+    @Override
     public void visitLMUL( LMUL obj ) {
     }
 
 
+    @Override
     public void visitLUSHR( LUSHR obj ) {
     }
 
 
+    @Override
     public void visitISHL( ISHL obj ) {
     }
 
 
+    @Override
     public void visitLALOAD( LALOAD obj ) {
     }
 
 
+    @Override
     public void visitASTORE( ASTORE obj ) {
     }
 
 
+    @Override
     public void visitANEWARRAY( ANEWARRAY obj ) {
     }
 
 
+    @Override
     public void visitFRETURN( FRETURN obj ) {
     }
 
 
+    @Override
     public void visitFADD( FADD obj ) {
     }
 
 
+    @Override
     public void visitBREAKPOINT( BREAKPOINT obj ) {
     }
 
     /**
      * @since 6.0
      */
+    @Override
     public void visitINVOKEDYNAMIC(INVOKEDYNAMIC obj) {
     }
 }

--- a/src/main/java/org/apache/commons/bcel6/generic/FCMPG.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FCMPG.java
@@ -35,6 +35,7 @@ public class FCMPG extends Instruction implements TypedInstruction, StackProduce
 
     /** @return Type.FLOAT
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.FLOAT;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/FCMPL.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FCMPL.java
@@ -35,6 +35,7 @@ public class FCMPL extends Instruction implements TypedInstruction, StackProduce
 
     /** @return Type.FLOAT
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.FLOAT;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/FCONST.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FCONST.java
@@ -53,6 +53,7 @@ public class FCONST extends Instruction implements ConstantPushInstruction {
     }
 
 
+    @Override
     public Number getValue() {
         return new Float(value);
     }
@@ -60,6 +61,7 @@ public class FCONST extends Instruction implements ConstantPushInstruction {
 
     /** @return Type.FLOAT
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.FLOAT;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/FieldGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FieldGen.java
@@ -46,6 +46,7 @@ public class FieldGen extends FieldGenOrMethodGen {
     private Object value = null;
     private static BCELComparator _cmp = new BCELComparator() {
 
+        @Override
         public boolean equals( Object o1, Object o2 ) {
             FieldGen THIS = (FieldGen) o1;
             FieldGen THAT = (FieldGen) o2;
@@ -54,6 +55,7 @@ public class FieldGen extends FieldGenOrMethodGen {
         }
 
 
+        @Override
         public int hashCode( Object o ) {
             FieldGen THIS = (FieldGen) o;
             return THIS.getSignature().hashCode() ^ THIS.getName().hashCode();

--- a/src/main/java/org/apache/commons/bcel6/generic/FieldGenOrMethodGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FieldGenOrMethodGen.java
@@ -48,6 +48,7 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
         super(access_flags);
     }
 
+    @Override
     public void setType( Type type ) { // TODO could be package-protected?
         if (type.getType() == Constants.T_ADDRESS) {
             throw new IllegalArgumentException("Type can not be " + type);
@@ -56,6 +57,7 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
     }
 
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -63,11 +65,13 @@ public abstract class FieldGenOrMethodGen extends AccessFlags implements NamedAn
 
     /** @return name of method/field.
      */
+    @Override
     public String getName() {
         return name;
     }
 
 
+    @Override
     public void setName( String name ) { // TODO could be package-protected?
         this.name = name;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/FieldOrMethod.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/FieldOrMethod.java
@@ -119,6 +119,7 @@ public abstract class FieldOrMethod extends CPInstruction implements LoadClass {
 
     /** @return type of the referenced class/interface
      */
+    @Override
     public ObjectType getLoadClassType( ConstantPoolGen cpg ) {
         return (ObjectType)getReferenceType(cpg);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/GETFIELD.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/GETFIELD.java
@@ -53,6 +53,7 @@ public class GETFIELD extends FieldInstruction implements ExceptionThrower, Stac
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_FIELD_AND_METHOD_RESOLUTION,
             ExceptionConstants.NULL_POINTER_EXCEPTION,

--- a/src/main/java/org/apache/commons/bcel6/generic/GETSTATIC.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/GETSTATIC.java
@@ -52,6 +52,7 @@ public class GETSTATIC extends FieldInstruction implements PushInstruction, Exce
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_FIELD_AND_METHOD_RESOLUTION,
             ExceptionConstants.INCOMPATIBLE_CLASS_CHANGE_ERROR);

--- a/src/main/java/org/apache/commons/bcel6/generic/ICONST.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ICONST.java
@@ -49,6 +49,7 @@ public class ICONST extends Instruction implements ConstantPushInstruction {
     }
 
 
+    @Override
     public Number getValue() {
         return Integer.valueOf(value);
     }
@@ -56,6 +57,7 @@ public class ICONST extends Instruction implements ConstantPushInstruction {
 
     /** @return Type.INT
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.INT;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/IDIV.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/IDIV.java
@@ -37,6 +37,7 @@ public class IDIV extends ArithmeticInstruction implements ExceptionThrower {
 
     /** @return exceptions this instruction may cause
      */
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.ARITHMETIC_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/INSTANCEOF.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/INSTANCEOF.java
@@ -44,11 +44,13 @@ public class INSTANCEOF extends CPInstruction implements LoadClass, ExceptionThr
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_CLASS_AND_INTERFACE_RESOLUTION);
     }
 
 
+    @Override
     public ObjectType getLoadClassType( ConstantPoolGen cpg ) {
         Type t = getType(cpg);
         if (t instanceof ArrayType) {

--- a/src/main/java/org/apache/commons/bcel6/generic/INVOKEDYNAMIC.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/INVOKEDYNAMIC.java
@@ -85,6 +85,7 @@ public class INVOKEDYNAMIC extends InvokeInstruction {
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_INTERFACE_METHOD_RESOLUTION,
             ExceptionConstants.UNSATISFIED_LINK_ERROR,

--- a/src/main/java/org/apache/commons/bcel6/generic/INVOKEINTERFACE.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/INVOKEINTERFACE.java
@@ -104,6 +104,7 @@ public final class INVOKEINTERFACE extends InvokeInstruction {
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_INTERFACE_METHOD_RESOLUTION,
             ExceptionConstants.UNSATISFIED_LINK_ERROR,

--- a/src/main/java/org/apache/commons/bcel6/generic/INVOKESPECIAL.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/INVOKESPECIAL.java
@@ -46,6 +46,7 @@ public class INVOKESPECIAL extends InvokeInstruction {
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_FIELD_AND_METHOD_RESOLUTION,
             ExceptionConstants.NULL_POINTER_EXCEPTION, 

--- a/src/main/java/org/apache/commons/bcel6/generic/INVOKESTATIC.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/INVOKESTATIC.java
@@ -45,6 +45,7 @@ public class INVOKESTATIC extends InvokeInstruction {
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_FIELD_AND_METHOD_RESOLUTION,
             ExceptionConstants.UNSATISFIED_LINK_ERROR,

--- a/src/main/java/org/apache/commons/bcel6/generic/INVOKEVIRTUAL.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/INVOKEVIRTUAL.java
@@ -45,6 +45,7 @@ public class INVOKEVIRTUAL extends InvokeInstruction {
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_FIELD_AND_METHOD_RESOLUTION,
             ExceptionConstants.NULL_POINTER_EXCEPTION,

--- a/src/main/java/org/apache/commons/bcel6/generic/IREM.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/IREM.java
@@ -37,6 +37,7 @@ public class IREM extends ArithmeticInstruction implements ExceptionThrower {
 
     /** @return exceptions this instruction may cause
      */
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.ARITHMETIC_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/InstructionComparator.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/InstructionComparator.java
@@ -33,6 +33,7 @@ public interface InstructionComparator {
 
     public static final InstructionComparator DEFAULT = new InstructionComparator() {
 
+        @Override
         public boolean equals( Instruction i1, Instruction i2 ) {
             if (i1.opcode == i2.opcode) {
                 if (i1 instanceof Select) {

--- a/src/main/java/org/apache/commons/bcel6/generic/InstructionList.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/InstructionList.java
@@ -1003,6 +1003,7 @@ public class InstructionList implements Serializable {
             private InstructionHandle ih = start;
 
 
+            @Override
             public InstructionHandle next() throws NoSuchElementException {
                 if (ih == null) {
                     throw new NoSuchElementException();
@@ -1013,11 +1014,13 @@ public class InstructionList implements Serializable {
             }
 
 
+            @Override
             public void remove() {
                 throw new UnsupportedOperationException();
             }
 
 
+            @Override
             public boolean hasNext() {
                 return ih != null;
             }

--- a/src/main/java/org/apache/commons/bcel6/generic/JsrInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/JsrInstruction.java
@@ -43,6 +43,7 @@ public abstract class JsrInstruction extends BranchInstruction implements Uncond
 
     /** @return return address type
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return new ReturnaddressType(physicalSuccessor());
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/LCMP.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LCMP.java
@@ -36,6 +36,7 @@ public class LCMP extends Instruction implements TypedInstruction, StackProducer
 
     /** @return Type.LONG
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.LONG;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/LCONST.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LCONST.java
@@ -51,6 +51,7 @@ public class LCONST extends Instruction implements ConstantPushInstruction {
     }
 
 
+    @Override
     public Number getValue() {
         return Long.valueOf(value);
     }
@@ -58,6 +59,7 @@ public class LCONST extends Instruction implements ConstantPushInstruction {
 
     /** @return Type.LONG
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.LONG;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/LDC.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LDC.java
@@ -134,6 +134,7 @@ public class LDC extends CPInstruction implements PushInstruction, ExceptionThro
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_STRING_RESOLUTION);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/LDIV.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LDIV.java
@@ -34,6 +34,7 @@ public class LDIV extends ArithmeticInstruction implements ExceptionThrower {
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.ARITHMETIC_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/LREM.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LREM.java
@@ -33,6 +33,7 @@ public class LREM extends ArithmeticInstruction implements ExceptionThrower {
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.ARITHMETIC_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/LineNumberGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LineNumberGen.java
@@ -48,6 +48,7 @@ public class LineNumberGen implements InstructionTargeter, Cloneable, java.io.Se
     /**
      * @return true, if ih is target of this line number
      */
+    @Override
     public boolean containsTarget( InstructionHandle ih ) {
         return this.ih == ih;
     }
@@ -57,6 +58,7 @@ public class LineNumberGen implements InstructionTargeter, Cloneable, java.io.Se
      * @param old_ih old target
      * @param new_ih new target
      */
+    @Override
     public void updateTarget( InstructionHandle old_ih, InstructionHandle new_ih ) {
         if (old_ih != ih) {
             throw new ClassGenException("Not targeting " + old_ih + ", but " + ih + "}");

--- a/src/main/java/org/apache/commons/bcel6/generic/LocalVariableGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LocalVariableGen.java
@@ -104,21 +104,25 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
     }
 
 
+    @Override
     public void setName( String name ) { // TODO unused
         this.name = name;
     }
 
 
+    @Override
     public String getName() {
         return name;
     }
 
 
+    @Override
     public void setType( Type type ) { // TODO unused
         this.type = type;
     }
 
 
+    @Override
     public Type getType() {
         return type;
     }
@@ -150,6 +154,7 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
      * @param old_ih old target, either start or end
      * @param new_ih new target
      */
+    @Override
     public void updateTarget( InstructionHandle old_ih, InstructionHandle new_ih ) {
         boolean targeted = false;
         if (start == old_ih) {
@@ -177,6 +182,7 @@ public class LocalVariableGen implements InstructionTargeter, NamedAndTyped, Clo
     /**
      * @return true, if ih is target of this variable
      */
+    @Override
     public boolean containsTarget( InstructionHandle ih ) {
         return (start == ih) || (end == ih);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/LocalVariableInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/LocalVariableInstruction.java
@@ -143,6 +143,7 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
     /**
      * @return local variable index  referred by this instruction.
      */
+    @Override
     public final int getIndex() {
         return n;
     }
@@ -151,6 +152,7 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
     /**
      * Set the local variable index
      */
+    @Override
     public void setIndex( int n ) { // TODO could be package-protected?
         if ((n < 0) || (n > Constants.MAX_SHORT)) {
             throw new ClassGenException("Illegal value: " + n);
@@ -185,6 +187,7 @@ public abstract class LocalVariableInstruction extends Instruction implements Ty
      * ASTORE may even work on a ReturnaddressType .
      * @return type associated with the instruction
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         switch (canon_tag) {
             case Constants.ILOAD:

--- a/src/main/java/org/apache/commons/bcel6/generic/MONITORENTER.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/MONITORENTER.java
@@ -33,6 +33,7 @@ public class MONITORENTER extends Instruction implements ExceptionThrower, Stack
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.NULL_POINTER_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/MONITOREXIT.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/MONITOREXIT.java
@@ -33,6 +33,7 @@ public class MONITOREXIT extends Instruction implements ExceptionThrower, StackC
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.NULL_POINTER_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/MULTIANEWARRAY.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/MULTIANEWARRAY.java
@@ -115,6 +115,7 @@ public class MULTIANEWARRAY extends CPInstruction implements LoadClass, Allocati
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_CLASS_AND_INTERFACE_RESOLUTION,
             ExceptionConstants.ILLEGAL_ACCESS_ERROR,
@@ -122,6 +123,7 @@ public class MULTIANEWARRAY extends CPInstruction implements LoadClass, Allocati
     }
 
 
+    @Override
     public ObjectType getLoadClassType( ConstantPoolGen cpg ) {
         Type t = getType(cpg);
         if (t instanceof ArrayType) {

--- a/src/main/java/org/apache/commons/bcel6/generic/MethodGen.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/MethodGen.java
@@ -79,6 +79,7 @@ public class MethodGen extends FieldGenOrMethodGen {
 
     private static BCELComparator _cmp = new BCELComparator() {
 
+        @Override
         public boolean equals( Object o1, Object o2 ) {
             MethodGen THIS = (MethodGen) o1;
             MethodGen THAT = (MethodGen) o2;
@@ -87,6 +88,7 @@ public class MethodGen extends FieldGenOrMethodGen {
         }
 
 
+        @Override
         public int hashCode( Object o ) {
             MethodGen THIS = (MethodGen) o;
             return THIS.getSignature().hashCode() ^ THIS.getName().hashCode();
@@ -369,6 +371,7 @@ public class MethodGen extends FieldGenOrMethodGen {
         }
         if (size > 1) {
             Arrays.sort(lg, new Comparator<LocalVariableGen>() {
+                @Override
                 public int compare(LocalVariableGen o1, LocalVariableGen o2) {
                     return o1.getIndex() - o2.getIndex();
                 }

--- a/src/main/java/org/apache/commons/bcel6/generic/NEW.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/NEW.java
@@ -44,6 +44,7 @@ public class NEW extends CPInstruction implements LoadClass, AllocationInstructi
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_CLASS_AND_INTERFACE_RESOLUTION,
             ExceptionConstants.ILLEGAL_ACCESS_ERROR,
@@ -51,6 +52,7 @@ public class NEW extends CPInstruction implements LoadClass, AllocationInstructi
     }
 
 
+    @Override
     public ObjectType getLoadClassType( ConstantPoolGen cpg ) {
         return (ObjectType) getType(cpg);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/NEWARRAY.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/NEWARRAY.java
@@ -101,6 +101,7 @@ public class NEWARRAY extends Instruction implements AllocationInstruction, Exce
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             org.apache.commons.bcel6.ExceptionConstants.NEGATIVE_ARRAY_SIZE_EXCEPTION

--- a/src/main/java/org/apache/commons/bcel6/generic/PUSH.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/PUSH.java
@@ -170,6 +170,7 @@ public final class PUSH implements CompoundInstruction, VariableLengthInstructio
     }
 
 
+    @Override
     public final InstructionList getInstructionList() {
         return new InstructionList(instruction);
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/PUTFIELD.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/PUTFIELD.java
@@ -52,6 +52,7 @@ public class PUTFIELD extends FieldInstruction implements PopInstruction, Except
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_FIELD_AND_METHOD_RESOLUTION,
             ExceptionConstants.NULL_POINTER_EXCEPTION,

--- a/src/main/java/org/apache/commons/bcel6/generic/PUTSTATIC.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/PUTSTATIC.java
@@ -52,6 +52,7 @@ public class PUTSTATIC extends FieldInstruction implements ExceptionThrower, Pop
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return ExceptionConstants.createExceptions(ExceptionConstants.EXCS.EXCS_FIELD_AND_METHOD_RESOLUTION,
             ExceptionConstants.INCOMPATIBLE_CLASS_CHANGE_ERROR);

--- a/src/main/java/org/apache/commons/bcel6/generic/RET.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/RET.java
@@ -97,6 +97,7 @@ public class RET extends Instruction implements IndexedInstruction, TypedInstruc
     /**
      * @return index of local variable containg the return address
      */
+    @Override
     public final int getIndex() {
         return index;
     }
@@ -105,6 +106,7 @@ public class RET extends Instruction implements IndexedInstruction, TypedInstruc
     /**
      * Set index of local variable containg the return address
      */
+    @Override
     public final void setIndex( int n ) {
         if (n < 0) {
             throw new ClassGenException("Negative index value: " + n);
@@ -125,6 +127,7 @@ public class RET extends Instruction implements IndexedInstruction, TypedInstruc
 
     /** @return return address type
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return ReturnaddressType.NO_TARGET;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/ReturnInstruction.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/ReturnInstruction.java
@@ -67,6 +67,7 @@ public abstract class ReturnInstruction extends Instruction implements Exception
     }
 
 
+    @Override
     public Class<?>[] getExceptions() {
         return new Class[] {
             ExceptionConstants.ILLEGAL_MONITOR_STATE
@@ -76,6 +77,7 @@ public abstract class ReturnInstruction extends Instruction implements Exception
 
     /** @return type associated with the instruction
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return getType();
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/SIPUSH.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/SIPUSH.java
@@ -78,6 +78,7 @@ public class SIPUSH extends Instruction implements ConstantPushInstruction {
     }
 
 
+    @Override
     public Number getValue() {
         return Integer.valueOf(b);
     }
@@ -85,6 +86,7 @@ public class SIPUSH extends Instruction implements ConstantPushInstruction {
 
     /** @return Type.SHORT
      */
+    @Override
     public Type getType( ConstantPoolGen cp ) {
         return Type.SHORT;
     }

--- a/src/main/java/org/apache/commons/bcel6/generic/SWITCH.java
+++ b/src/main/java/org/apache/commons/bcel6/generic/SWITCH.java
@@ -142,6 +142,7 @@ public final class SWITCH implements CompoundInstruction {
     }
 
 
+    @Override
     public final InstructionList getInstructionList() {
         return new InstructionList(instruction);
     }

--- a/src/main/java/org/apache/commons/bcel6/util/ClassLoaderRepository.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassLoaderRepository.java
@@ -51,6 +51,7 @@ public class ClassLoaderRepository implements Repository {
     /**
      * Store a new JavaClass into this Repository.
      */
+    @Override
     public void storeClass( JavaClass clazz ) {
         loadedClasses.put(clazz.getClassName(), clazz);
         clazz.setRepository(this);
@@ -60,6 +61,7 @@ public class ClassLoaderRepository implements Repository {
     /**
      * Remove class from repository
      */
+    @Override
     public void removeClass( JavaClass clazz ) {
         loadedClasses.remove(clazz.getClassName());
     }
@@ -68,6 +70,7 @@ public class ClassLoaderRepository implements Repository {
     /**
      * Find an already defined JavaClass.
      */
+    @Override
     public JavaClass findClass( String className ) {
         return loadedClasses.containsKey(className) ? loadedClasses.get(className) : null;
     }
@@ -76,6 +79,7 @@ public class ClassLoaderRepository implements Repository {
     /**
      * Lookup a JavaClass object from the Class Name provided.
      */
+    @Override
     public JavaClass loadClass( String className ) throws ClassNotFoundException {
         String classFile = className.replace('.', '/');
         JavaClass RC = findClass(className);
@@ -101,6 +105,7 @@ public class ClassLoaderRepository implements Repository {
     }
 
 
+    @Override
     public JavaClass loadClass( Class<?> clazz ) throws ClassNotFoundException {
         return loadClass(clazz.getName());
     }
@@ -108,6 +113,7 @@ public class ClassLoaderRepository implements Repository {
 
     /** Clear all entries from cache.
      */
+    @Override
     public void clear() {
         loadedClasses.clear();
     }
@@ -116,6 +122,7 @@ public class ClassLoaderRepository implements Repository {
     /*
      * @return null
      */
+    @Override
     public ClassPath getClassPath() {
         return null;
     }

--- a/src/main/java/org/apache/commons/bcel6/util/ClassPath.java
+++ b/src/main/java/org/apache/commons/bcel6/util/ClassPath.java
@@ -48,6 +48,7 @@ public class ClassPath implements Serializable {
 
     private static final FilenameFilter ARCHIVE_FILTER = new FilenameFilter() {
 
+        @Override
         public boolean accept( File dir, String name ) {
             name = name.toLowerCase(Locale.ENGLISH);
             return name.endsWith(".zip") || name.endsWith(".jar");
@@ -421,11 +422,13 @@ public class ClassPath implements Serializable {
                     + name.replace('.', File.separatorChar) + suffix);
             return file.exists() ? new ClassFile() {
 
+                @Override
                 public InputStream getInputStream() throws IOException {
                     return new FileInputStream(file);
                 }
 
 
+                @Override
                 public String getPath() {
                     try {
                         return file.getCanonicalPath();
@@ -435,16 +438,19 @@ public class ClassPath implements Serializable {
                 }
 
 
+                @Override
                 public long getTime() {
                     return file.lastModified();
                 }
 
 
+                @Override
                 public long getSize() {
                     return file.length();
                 }
 
 
+                @Override
                 public String getBase() {
                     return dir;
                 }
@@ -498,26 +504,31 @@ public class ClassPath implements Serializable {
 
             return new ClassFile() {
 
+                @Override
                 public InputStream getInputStream() throws IOException {
                     return zip.getInputStream(entry);
                 }
 
 
+                @Override
                 public String getPath() {
                     return entry.toString();
                 }
 
 
+                @Override
                 public long getTime() {
                     return entry.getTime();
                 }
 
 
+                @Override
                 public long getSize() {
                     return entry.getSize();
                 }
 
 
+                @Override
                 public String getBase() {
                     return zip.getName();
                 }

--- a/src/main/java/org/apache/commons/bcel6/util/SyntheticRepository.java
+++ b/src/main/java/org/apache/commons/bcel6/util/SyntheticRepository.java
@@ -72,6 +72,7 @@ public class SyntheticRepository implements Repository {
     /**
      * Store a new JavaClass instance into this Repository.
      */
+    @Override
     public void storeClass( JavaClass clazz ) {
         _loadedClasses.put(clazz.getClassName(), new SoftReference<JavaClass>(clazz));
         clazz.setRepository(this);
@@ -81,6 +82,7 @@ public class SyntheticRepository implements Repository {
     /**
      * Remove class from repository
      */
+    @Override
     public void removeClass( JavaClass clazz ) {
         _loadedClasses.remove(clazz.getClassName());
     }
@@ -89,6 +91,7 @@ public class SyntheticRepository implements Repository {
     /**
      * Find an already defined (cached) JavaClass object by name.
      */
+    @Override
     public JavaClass findClass( String className ) {
         SoftReference<JavaClass> ref = _loadedClasses.get(className);
         if (ref == null) {
@@ -109,6 +112,7 @@ public class SyntheticRepository implements Repository {
      * @throws ClassNotFoundException if the class is not in the
      *   Repository, and could not be found on the classpath
      */
+    @Override
     public JavaClass loadClass( String className ) throws ClassNotFoundException {
         if (className == null || className.equals("")) {
             throw new IllegalArgumentException("Invalid class name " + className);
@@ -140,6 +144,7 @@ public class SyntheticRepository implements Repository {
      * @throws ClassNotFoundException if the class is not in the
      *   Repository, and its representation could not be found
      */
+    @Override
     public JavaClass loadClass( Class<?> clazz ) throws ClassNotFoundException {
         InputStream clsStream = null;
         try{
@@ -192,6 +197,7 @@ public class SyntheticRepository implements Repository {
 
     /** ClassPath associated with the Repository.
      */
+    @Override
     public ClassPath getClassPath() {
         return _path;
     }
@@ -199,6 +205,7 @@ public class SyntheticRepository implements Repository {
 
     /** Clear all entries from cache.
      */
+    @Override
     public void clear() {
         _loadedClasses.clear();
     }

--- a/src/main/java/org/apache/commons/bcel6/verifier/TransitiveHull.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/TransitiveHull.java
@@ -40,6 +40,7 @@ public class TransitiveHull implements VerifierFactoryObserver {
 
 
     /* Implementing VerifierFactoryObserver. */
+    @Override
     public void update( String classname ) {
         System.gc(); // avoid swapping if possible.
         for (int i = 0; i < indent; i++) {

--- a/src/main/java/org/apache/commons/bcel6/verifier/VerifierAppFrame.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/VerifierAppFrame.java
@@ -128,6 +128,7 @@ public class VerifierAppFrame extends JFrame {
         messagesScrollPane.setPreferredSize(new Dimension(10, 10));
         classNamesJList.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
 
+            @Override
             public void valueChanged( ListSelectionEvent e ) {
                 classNamesJList_valueChanged(e);
             }
@@ -152,6 +153,7 @@ public class VerifierAppFrame extends JFrame {
                 InputEvent.CTRL_MASK, true));
         newFileMenuItem.addActionListener(new java.awt.event.ActionListener() {
 
+            @Override
             public void actionPerformed( ActionEvent e ) {
                 newFileMenuItem_actionPerformed(e);
             }
@@ -160,12 +162,14 @@ public class VerifierAppFrame extends JFrame {
         pass3bTextPane.setEditable(false);
         pass3aJList.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
 
+            @Override
             public void valueChanged( ListSelectionEvent e ) {
                 pass3aJList_valueChanged(e);
             }
         });
         pass3bJList.addListSelectionListener(new javax.swing.event.ListSelectionListener() {
 
+            @Override
             public void valueChanged( ListSelectionEvent e ) {
                 pass3bJList_valueChanged(e);
             }
@@ -174,6 +178,7 @@ public class VerifierAppFrame extends JFrame {
         whatisMenuItem.setText("What is...");
         whatisMenuItem.addActionListener(new java.awt.event.ActionListener() {
 
+            @Override
             public void actionPerformed( ActionEvent e ) {
                 whatisMenuItem_actionPerformed(e);
             }
@@ -181,6 +186,7 @@ public class VerifierAppFrame extends JFrame {
         aboutMenuItem.setText("About");
         aboutMenuItem.addActionListener(new java.awt.event.ActionListener() {
 
+            @Override
             public void actionPerformed( ActionEvent e ) {
                 aboutMenuItem_actionPerformed(e);
             }

--- a/src/main/java/org/apache/commons/bcel6/verifier/VerifierFactoryListModel.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/VerifierFactoryListModel.java
@@ -44,6 +44,7 @@ public class VerifierFactoryListModel implements org.apache.commons.bcel6.verifi
     }
 
 
+    @Override
     public synchronized void update( String s ) {
         Verifier[] verifiers = VerifierFactory.getVerifiers();
         int num_of_verifiers = verifiers.length;
@@ -58,21 +59,25 @@ public class VerifierFactoryListModel implements org.apache.commons.bcel6.verifi
     }
 
 
+    @Override
     public synchronized void addListDataListener( ListDataListener l ) {
         listeners.add(l);
     }
 
 
+    @Override
     public synchronized void removeListDataListener( javax.swing.event.ListDataListener l ) {
         listeners.remove(l);
     }
 
 
+    @Override
     public synchronized int getSize() {
         return cache.size();
     }
 
 
+    @Override
     public synchronized String getElementAt( int index ) {
         return (cache.toArray(new String[cache.size()]))[index];
     }

--- a/src/main/java/org/apache/commons/bcel6/verifier/VerifyDialog.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/VerifyDialog.java
@@ -70,6 +70,7 @@ public class VerifyDialog extends javax.swing.JDialog {
     /** Machine-generated. */
     class IvjEventHandler implements java.awt.event.ActionListener {
 
+        @Override
         public void actionPerformed( java.awt.event.ActionEvent e ) {
             if (e.getSource() == VerifyDialog.this.getPass1Button()) {
                 connEtoC1(e);

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/ControlFlowGraph.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/ControlFlowGraph.java
@@ -94,11 +94,13 @@ public class ControlFlowGraph{
         }
 
         /* Satisfies InstructionContext.getTag(). */
+        @Override
         public int getTag(){
             return TAG;
         }
 
         /* Satisfies InstructionContext.setTag(int). */
+        @Override
         public void setTag(int tag){ // part of InstructionContext interface
             TAG = tag;
         }
@@ -106,6 +108,7 @@ public class ControlFlowGraph{
         /**
          * Returns the exception handlers of this instruction.
          */
+        @Override
         public ExceptionHandler[] getExceptionHandlers(){
             return exceptionhandlers.getExceptionHandlers(getInstruction());
         }
@@ -113,6 +116,7 @@ public class ControlFlowGraph{
         /**
          * Returns a clone of the "outgoing" frame situation with respect to the given ExecutionChain.
          */    
+        @Override
         public Frame getOutFrame(ArrayList<InstructionContext> execChain){
             executionPredecessors = execChain;
 
@@ -128,6 +132,7 @@ public class ControlFlowGraph{
             return org.getClone();
         }
 
+    @Override
     public Frame getInFrame() {
           Frame org;
 
@@ -156,6 +161,7 @@ public class ControlFlowGraph{
          * @return true - if and only if the "outgoing" frame situation
          * changed from the one before execute()ing.
          */
+        @Override
         public boolean execute(Frame inFrame, ArrayList<InstructionContext> execPreds, InstConstraintVisitor icv, ExecutionVisitor ev){
 
             @SuppressWarnings("unchecked") // OK because execPreds is compatible type
@@ -273,6 +279,7 @@ public class ControlFlowGraph{
         /*
          * Fulfils the contract of InstructionContext.getInstruction().
          */
+        @Override
         public InstructionHandle getInstruction(){
             return instruction;
         }
@@ -306,6 +313,7 @@ public class ControlFlowGraph{
         }
 
         /* Satisfies InstructionContext.getSuccessors(). */
+        @Override
         public InstructionContext[] getSuccessors(){
             return contextsOf(_getSuccessors());
         }

--- a/src/main/java/org/apache/commons/bcel6/verifier/structurals/Subroutines.java
+++ b/src/main/java/org/apache/commons/bcel6/verifier/structurals/Subroutines.java
@@ -90,6 +90,7 @@ public class Subroutines{
         /*
          * Refer to the Subroutine interface for documentation.
          */
+        @Override
         public boolean contains(InstructionHandle inst){
             return instructions.contains(inst);
         }
@@ -162,6 +163,7 @@ public class Subroutines{
         /*
          * Refer to the Subroutine interface for documentation.
          */
+        @Override
         public InstructionHandle[] getEnteringJsrInstructions(){
             if (this == TOPLEVEL) {
                 throw new AssertionViolatedException("getLeavingRET() called on top level pseudo-subroutine.");
@@ -192,6 +194,7 @@ public class Subroutines{
         /*
          * Refer to the Subroutine interface for documentation.
          */
+        @Override
         public InstructionHandle getLeavingRET(){
             if (this == TOPLEVEL) {
                 throw new AssertionViolatedException("getLeavingRET() called on top level pseudo-subroutine.");
@@ -202,6 +205,7 @@ public class Subroutines{
         /*
          * Refer to the Subroutine interface for documentation.
          */
+        @Override
         public InstructionHandle[] getInstructions(){
             InstructionHandle[] ret = new InstructionHandle[instructions.size()];
             return instructions.toArray(ret);
@@ -220,6 +224,7 @@ public class Subroutines{
         }
 
         /* Satisfies Subroutine.getRecursivelyAccessedLocalsIndices(). */
+        @Override
         public int[] getRecursivelyAccessedLocalsIndices(){
             Set<Integer> s = new HashSet<Integer>();
             int[] lvs = getAccessedLocalsIndices();
@@ -255,6 +260,7 @@ public class Subroutines{
         /*
          * Satisfies Subroutine.getAccessedLocalIndices().
          */
+        @Override
         public int[] getAccessedLocalsIndices(){
             //TODO: Implement caching.
             Set<Integer> acc = new HashSet<Integer>();
@@ -299,6 +305,7 @@ public class Subroutines{
         /*
          * Satisfies Subroutine.subSubs().
          */
+        @Override
         public Subroutine[] subSubs(){
             Set<Subroutine> h = new HashSet<Subroutine>();
 

--- a/src/test/java/org/apache/commons/bcel6/BCELBenchmark.java
+++ b/src/test/java/org/apache/commons/bcel6/BCELBenchmark.java
@@ -59,6 +59,7 @@ public class BCELBenchmark {
 
     private Iterable<JarEntry> getClasses(JarFile jar) {
         return new IteratorIterable<JarEntry>(new FilterIterator<JarEntry>(new EnumerationIterator<JarEntry>(jar.entries()), new Predicate<JarEntry>() {
+            @Override
             public boolean evaluate(JarEntry entry) {
                 return entry.getName().endsWith(".class");
             }

--- a/src/test/java/org/apache/commons/bcel6/PerformanceTest.java
+++ b/src/test/java/org/apache/commons/bcel6/PerformanceTest.java
@@ -131,6 +131,7 @@ public final class PerformanceTest extends TestCase {
         File javaLib = new File(System.getProperty("java.home") + "/lib");
         javaLib.listFiles(new FileFilter() {
 
+            @Override
             public boolean accept(File file) {
                 if(file.getName().endsWith(".jar")) {
                     try {

--- a/src/test/java/org/apache/commons/bcel6/data/AnonymousClassTest.java
+++ b/src/test/java/org/apache/commons/bcel6/data/AnonymousClassTest.java
@@ -24,6 +24,7 @@ public class AnonymousClassTest
     {
         new Runnable()
         {
+            @Override
             public void run()
             {
             }

--- a/src/test/java/org/apache/commons/bcel6/data/AttributeTestClassEM02.java
+++ b/src/test/java/org/apache/commons/bcel6/data/AttributeTestClassEM02.java
@@ -22,6 +22,7 @@ public class AttributeTestClassEM02
 {
     Runnable r = new Runnable()
     {
+        @Override
         public void run()
         {
             System.err.println("hello");

--- a/src/test/java/org/apache/commons/bcel6/visitors/CounterVisitor.java
+++ b/src/test/java/org/apache/commons/bcel6/visitors/CounterVisitor.java
@@ -150,216 +150,259 @@ public class CounterVisitor implements Visitor
     public int methodParametersCount = 0;
 
 
+    @Override
     public void visitAnnotation(Annotations obj)
     {
         annotationCount++;
     }
 
+    @Override
     public void visitAnnotationDefault(AnnotationDefault obj)
     {
         annotationDefaultCount++;
     }
 
+    @Override
     public void visitAnnotationEntry(AnnotationEntry obj)
     {
         annotationEntryCount++;
     }
 
+    @Override
     public void visitCode(Code obj)
     {
         codeCount++;
     }
 
+    @Override
     public void visitCodeException(CodeException obj)
     {
         codeExceptionCount++;
     }
 
+    @Override
     public void visitConstantClass(ConstantClass obj)
     {
         constantClassCount++;
     }
 
+    @Override
     public void visitConstantDouble(ConstantDouble obj)
     {
         constantDoubleCount++;
     }
 
+    @Override
     public void visitConstantFieldref(ConstantFieldref obj)
     {
         constantFieldrefCount++;
     }
 
+    @Override
     public void visitConstantFloat(ConstantFloat obj)
     {
         constantFloatCount++;
     }
 
+    @Override
     public void visitConstantInteger(ConstantInteger obj)
     {
         constantIntegerCount++;
     }
 
+    @Override
     public void visitConstantInterfaceMethodref(ConstantInterfaceMethodref obj)
     {
         constantInterfaceMethodrefCount++;
     }
 
+    @Override
     public void visitConstantLong(ConstantLong obj)
     {
         constantLongCount++;
     }
 
+    @Override
     public void visitConstantMethodref(ConstantMethodref obj)
     {
         constantMethodrefCount++;
     }
 
+    @Override
     public void visitConstantNameAndType(ConstantNameAndType obj)
     {
         constantNameAndTypeCount++;
     }
 
+    @Override
     public void visitConstantPool(ConstantPool obj)
     {
         constantPoolCount++;
     }
 
+    @Override
     public void visitConstantString(ConstantString obj)
     {
         constantStringCount++;
     }
 
+    @Override
     public void visitConstantUtf8(ConstantUtf8 obj)
     {
         constantUtf8Count++;
     }
 
+    @Override
     public void visitConstantValue(ConstantValue obj)
     {
         constantValueCount++;
     }
 
+    @Override
     public void visitDeprecated(Deprecated obj)
     {
         deprecatedCount++;
     }
 
+    @Override
     public void visitEnclosingMethod(EnclosingMethod obj)
     {
         enclosingMethodCount++;
     }
 
+    @Override
     public void visitExceptionTable(ExceptionTable obj)
     {
         exceptionTableCount++;
     }
 
+    @Override
     public void visitField(Field obj)
     {
         fieldCount++;
     }
 
+    @Override
     public void visitInnerClass(InnerClass obj)
     {
         innerClassCount++;
     }
 
+    @Override
     public void visitInnerClasses(InnerClasses obj)
     {
         innerClassesCount++;
     }
 
+    @Override
     public void visitJavaClass(JavaClass obj)
     {
         javaClassCount++;
     }
 
+    @Override
     public void visitLineNumber(LineNumber obj)
     {
         lineNumberCount++;
     }
 
+    @Override
     public void visitLineNumberTable(LineNumberTable obj)
     {
         lineNumberTableCount++;
     }
 
+    @Override
     public void visitLocalVariable(LocalVariable obj)
     {
         localVariableCount++;
     }
 
+    @Override
     public void visitLocalVariableTable(LocalVariableTable obj)
     {
         localVariableTableCount++;
     }
 
+    @Override
     public void visitLocalVariableTypeTable(LocalVariableTypeTable obj)
     {
         localVariableTypeTableCount++;
     }
 
+    @Override
     public void visitMethod(Method obj)
     {
         methodCount++;
     }
 
+    @Override
     public void visitParameterAnnotation(ParameterAnnotations obj)
     {
         parameterAnnotationCount++;
     }
 
+    @Override
     public void visitSignature(Signature obj)
     {
         signatureAnnotationCount++;
     }
 
+    @Override
     public void visitSourceFile(SourceFile obj)
     {
         sourceFileCount++;
     }
 
+    @Override
     public void visitStackMap(StackMap obj)
     {
         stackMapCount++;
     }
 
+    @Override
     public void visitStackMapEntry(StackMapEntry obj)
     {
         stackMapEntryCount++;
     }
 
+    @Override
     public void visitSynthetic(Synthetic obj)
     {
         syntheticCount++;
     }
 
+    @Override
     public void visitUnknown(Unknown obj)
     {
         unknownCount++;
     }
 
+    @Override
     public void visitStackMapTable(StackMapTable obj)
     {
         stackMapTableCount++;
     }
 
+    @Override
     public void visitStackMapTableEntry(StackMapTableEntry obj)
     {
         stackMapTableEntryCount++;
     }
 
+    @Override
     public void visitBootstrapMethods(BootstrapMethods obj)
     {
         bootstrapMethodsCount++;
     }
 
+    @Override
     public void visitMethodParameters(MethodParameters obj)
     {
         methodParametersCount++;
     }
 
+    @Override
     public void visitConstantInvokeDynamic(ConstantInvokeDynamic obj)
     {
     }


### PR DESCRIPTION
Add missing '@Override' annotations to implementations of interface methods (requires Java 6  but we are now on 7  so all it good).
