### PR TITLE
BCEL-217 long type instructions are not searched by InstructionFinder

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -63,6 +63,7 @@ The <action> type attribute can be add,update,fix,remove.
 
   <body>
     <release version="6.0" date="TBA" description="Major release with Java 7 and 8 support">
+      <action issue="BCEL-217" type="fix">long type instructions are not searched by InstructionFinder using regular expression</action>
       <action issue="BCEL-244" type="update" dev="ggregory">Update Java requirement from 5 to 7</action>
       <action issue="BCEL-239" type="fix">Interfaces should not be used to define constants</action>
       <action issue="BCEL-235" type="fix">Remove unused setters</action>

--- a/src/main/java/org/apache/commons/bcel6/util/InstructionFinder.java
+++ b/src/main/java/org/apache/commons/bcel6/util/InstructionFinder.java
@@ -353,10 +353,12 @@ public class InstructionFinder {
         map.put("lconst", new String(new char[] { '(', makeChar(Constants.LCONST_0), '|', makeChar(Constants.LCONST_1), ')' }));
         map.put("dconst", new String(new char[] { '(', makeChar(Constants.DCONST_0), '|', makeChar(Constants.DCONST_1), ')' }));
         map.put("fconst", new String(new char[] { '(', makeChar(Constants.FCONST_0), '|', makeChar(Constants.FCONST_1), ')' }));
+        map.put("lload", precompile(Constants.LLOAD_0, Constants.LLOAD_3, Constants.LLOAD));
         map.put("iload", precompile(Constants.ILOAD_0, Constants.ILOAD_3, Constants.ILOAD));
         map.put("dload", precompile(Constants.DLOAD_0, Constants.DLOAD_3, Constants.DLOAD));
         map.put("fload", precompile(Constants.FLOAD_0, Constants.FLOAD_3, Constants.FLOAD));
         map.put("aload", precompile(Constants.ALOAD_0, Constants.ALOAD_3, Constants.ALOAD));
+        map.put("lstore", precompile(Constants.LSTORE_0, Constants.LSTORE_3, Constants.LSTORE));
         map.put("istore", precompile(Constants.ISTORE_0, Constants.ISTORE_3, Constants.ISTORE));
         map.put("dstore", precompile(Constants.DSTORE_0, Constants.DSTORE_3, Constants.DSTORE));
         map.put("fstore", precompile(Constants.FSTORE_0, Constants.FSTORE_3, Constants.FSTORE));


### PR DESCRIPTION
BCEL-217 long type instructions are not searched by InstructionFinder using regular expression  git-svn-id: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk@1695767 13f79535-47bb-0310-9956-ffa450edef68
